### PR TITLE
wind: earth.nullschool-style particle animation

### DIFF
--- a/crates/math/Cargo.toml
+++ b/crates/math/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sailor-math"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "sailor_math"

--- a/crates/math/src/geometry/polygon.rs
+++ b/crates/math/src/geometry/polygon.rs
@@ -50,11 +50,20 @@ impl Polygon {
 
     /// Even-odd containment across all rings.
     pub fn contains(&self, point: Vec2) -> bool {
-        self.rings.iter().filter(|ring| ring.contains(point)).count() % 2 == 1
+        self.rings
+            .iter()
+            .filter(|ring| ring.contains(point))
+            .count()
+            % 2
+            == 1
     }
 
     pub fn aabb(&self) -> Aabb {
-        Aabb::from_points(self.rings.iter().flat_map(|ring| ring.points().iter().copied()))
+        Aabb::from_points(
+            self.rings
+                .iter()
+                .flat_map(|ring| ring.points().iter().copied()),
+        )
     }
 
     pub fn rings(&self) -> &[Ring] {
@@ -117,7 +126,10 @@ mod tests {
         };
         assert!(poly.contains(Vec2::new(0.5, 0.5)), "inside first part");
         assert!(poly.contains(Vec2::new(10.5, 0.5)), "inside second part");
-        assert!(!poly.contains(Vec2::new(5.0, 0.5)), "in the gap between parts");
+        assert!(
+            !poly.contains(Vec2::new(5.0, 0.5)),
+            "in the gap between parts"
+        );
     }
 
     #[test]

--- a/crates/math/src/math/camera.rs
+++ b/crates/math/src/math/camera.rs
@@ -34,7 +34,12 @@ impl Camera {
 
     /// Tile field covering the view at zoom level `z` (a level query, so it keeps
     /// an explicit `z`: callers ask for `zoom` and `zoom - 1` to manage the pyramid).
-    pub fn get_tile_boundaries_for_zoom_level(&self, z: f32, scale: u32, overzoom: u32) -> TileField {
+    pub fn get_tile_boundaries_for_zoom_level(
+        &self,
+        z: f32,
+        scale: u32,
+        overzoom: u32,
+    ) -> TileField {
         let z = z.min(14.0);
         // Use the same fractional zoom as `global_to_screen` so the visible extent
         // matches what is actually rendered; using the integer floor here would
@@ -82,7 +87,11 @@ impl Camera {
         let s = 2.0f32.powf(self.zoom) * self.tile_size();
         Transform::from_mat(
             glm::scaling(&glm::vec3(s, s, 1.0))
-                * glm::translation(&glm::vec3(-self.center.x as f32, -self.center.y as f32, 0.0)),
+                * glm::translation(&glm::vec3(
+                    -self.center.x as f32,
+                    -self.center.y as f32,
+                    0.0,
+                )),
         )
     }
 
@@ -185,7 +194,16 @@ mod tests {
     #[test]
     fn zoom_to_cursor_accumulates_precisely() {
         let cursor = Coord::<Pixel>::new(1700.0, 300.0); // well off-centre
-        let make = || Camera::new(point(0.5187345, 0.5093721), 2400.0, 1400.0, 384.0, 2.0, 14.0);
+        let make = || {
+            Camera::new(
+                point(0.5187345, 0.5093721),
+                2400.0,
+                1400.0,
+                384.0,
+                2.0,
+                14.0,
+            )
+        };
 
         // Many small scroll steps from z14 up to ~z18.
         let mut stepwise = make();

--- a/crates/math/src/math/tile_field.rs
+++ b/crates/math/src/math/tile_field.rs
@@ -81,7 +81,14 @@ impl<'a> Iterator for TileIterator<'a> {
 #[test]
 fn get_tile_boundaries_for_8_zoom() {
     use super::*;
-    let bb = Camera::new(point(47.607_372, 6.114297), 800f32, 800f32, 256f32, 1.0, 8.0);
+    let bb = Camera::new(
+        point(47.607_372, 6.114297),
+        800f32,
+        800f32,
+        256f32,
+        1.0,
+        8.0,
+    );
     let tile_field = bb.get_tile_boundaries_for_zoom_level(8.0, 1, 0);
 
     assert_eq!(tile_field.iter().count(), 20);

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sailor-platform"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "sailor_platform"

--- a/crates/platform/src/http.rs
+++ b/crates/platform/src/http.rs
@@ -17,7 +17,12 @@ pub async fn get(url: &str) -> Option<Vec<u8>> {
 pub async fn get_range(url: &str, offset: u64, length: u64) -> Option<Vec<u8>> {
     let end = offset + length - 1;
     let client = reqwest::Client::new();
-    match client.get(url).header("Range", format!("bytes={offset}-{end}")).send().await {
+    match client
+        .get(url)
+        .header("Range", format!("bytes={offset}-{end}"))
+        .send()
+        .await
+    {
         Ok(r) if r.status() == reqwest::StatusCode::PARTIAL_CONTENT => {
             r.bytes().await.ok().map(|b| b.to_vec())
         }

--- a/crates/style/Cargo.toml
+++ b/crates/style/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sailor-style"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [lib]
 name = "sailor_style"

--- a/src/bin/app_state.rs
+++ b/src/bin/app_state.rs
@@ -1,9 +1,9 @@
 use lyon::math::Point;
 use nalgebra_glm::{Vec2, vec2};
+use osm::cache::CacheStats;
 use osm::css::RulesCache;
 use osm::feature::collection::FeatureCollection;
 use osm::math::{Camera, Coord, Geo, PointF64, TileId, deg2num, tile_to_world_space};
-use osm::cache::CacheStats;
 use osm::object::Object;
 use std::sync::{Arc, Mutex, RwLock};
 use winit::dpi::PhysicalSize;
@@ -114,7 +114,10 @@ impl AppState {
     }
 
     pub fn set_center(&mut self, center: (f32, f32)) {
-        let tile_coordinate = deg2num(Coord::<Geo>::new(center.1, center.0), self.screen.zoom as u32);
+        let tile_coordinate = deg2num(
+            Coord::<Geo>::new(center.1, center.0),
+            self.screen.zoom as u32,
+        );
         let p = tile_to_world_space(&tile_coordinate);
         self.screen.center = PointF64::new(p.x as f64, p.y as f64);
     }

--- a/src/bin/drawing/layer/hover.rs
+++ b/src/bin/drawing/layer/hover.rs
@@ -181,11 +181,17 @@ impl Layer for HoverLayer {
         self.jobs = self.ctx.tessellate(full.shapes, full.pixels_per_point);
         for (id, deltas) in &full.textures_delta.set {
             for delta in deltas {
-                self.renderer.update_texture(ctx.device, ctx.queue, *id, delta);
+                self.renderer
+                    .update_texture(ctx.device, ctx.queue, *id, delta);
             }
         }
-        self.renderer
-            .update_buffers(ctx.device, ctx.queue, ctx.encoder, &self.jobs, &self.descriptor);
+        self.renderer.update_buffers(
+            ctx.device,
+            ctx.queue,
+            ctx.encoder,
+            &self.jobs,
+            &self.descriptor,
+        );
         self.free = full.textures_delta.free.iter().copied().collect();
     }
 
@@ -212,6 +218,7 @@ impl Layer for HoverLayer {
                 multiview_mask: None,
             })
             .forget_lifetime();
-        self.renderer.render(&mut pass, &self.jobs, &self.descriptor);
+        self.renderer
+            .render(&mut pass, &self.jobs, &self.descriptor);
     }
 }

--- a/src/bin/drawing/layer/legend.rs
+++ b/src/bin/drawing/layer/legend.rs
@@ -9,8 +9,8 @@ use super::{FramePass, Layer, LayerCtx};
 /// Bar geometry in physical pixels (sized for hidpi/retina).
 const BAR_W: f32 = 360.0;
 const BAR_H: f32 = 28.0;
-const MARGIN_X: f32 = 40.0;
-const MARGIN_BOTTOM: f32 = 64.0;
+/// Gap from the top of the map to the bar (clears the top frametime strip).
+const MARGIN_TOP: f32 = 56.0;
 /// TextArea scale — matches the map's retina text handling.
 const LABEL_SCALE: f32 = 2.0;
 /// Tick labels along the bar (knots).
@@ -180,8 +180,8 @@ impl Layer for LegendLayer {
         }
 
         let (w, h) = (ctx.resolution.0 as f32, ctx.resolution.1 as f32);
-        // bottom-left corner; rect = [x, y_top, width, height] in pixels.
-        self.rect = [MARGIN_X, h - MARGIN_BOTTOM - BAR_H, BAR_W, BAR_H];
+        // top-centre; rect = [x, y_top, width, height] in pixels.
+        self.rect = [(w - BAR_W) / 2.0, MARGIN_TOP, BAR_W, BAR_H];
         let u = [
             w,
             h,

--- a/src/bin/drawing/layer/legend.rs
+++ b/src/bin/drawing/layer/legend.rs
@@ -1,0 +1,256 @@
+use glyphon::{Attrs, Buffer, Color, Family, Metrics, Shaping, TextArea, TextBounds, TextRenderer};
+use osm::drawing::as_byte_slice;
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu::*;
+
+use super::text::TextStack;
+use super::{FramePass, Layer, LayerCtx};
+
+/// Bar geometry in physical pixels.
+const BAR_W: f32 = 260.0;
+const BAR_H: f32 = 14.0;
+const MARGIN_X: f32 = 24.0;
+const MARGIN_BOTTOM: f32 = 40.0;
+/// Tick labels along the bar (knots).
+const TICKS: [&str; 6] = ["0", "10", "20", "30", "40", "50 kn"];
+
+const GRADIENT_WGSL: &str = r#"
+struct LU { viewport: vec2<f32>, rect_pos: vec2<f32>, rect_size: vec2<f32>, pad: vec2<f32> };
+@group(0) @binding(0) var<uniform> u: LU;
+
+struct VsOut { @builtin(position) pos: vec4<f32>, @location(0) t: f32 };
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    // triangle-strip quad corners (x across the bar, y down it)
+    var corners = array<vec2<f32>, 4>(vec2(0.0, 0.0), vec2(0.0, 1.0), vec2(1.0, 0.0), vec2(1.0, 1.0));
+    let c = corners[vi];
+    let px = u.rect_pos + c * u.rect_size;
+    let ndc = vec2<f32>(px.x / u.viewport.x * 2.0 - 1.0, 1.0 - px.y / u.viewport.y * 2.0);
+    var out: VsOut;
+    out.pos = vec4<f32>(ndc, 0.0, 1.0);
+    out.t = c.x;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    return vec4<f32>(wind_color(in.t * 50.0), 0.92);
+}
+"#;
+
+/// On-map wind-speed color legend: a gradient bar plus knots tick labels, using
+/// the shared palette and the shared glyphon atlas. Shown when the wind overlay
+/// is visible.
+pub struct LegendLayer {
+    pipeline: RenderPipeline,
+    bind_group: BindGroup,
+    uniform: Buffer_,
+    text_renderer: TextRenderer,
+    labels: Vec<Buffer>,
+    rect: [f32; 4],
+    visible: bool,
+}
+
+// `wgpu::Buffer` and `glyphon::Buffer` clash by name; alias the wgpu one.
+type Buffer_ = wgpu::Buffer;
+
+impl LegendLayer {
+    pub fn new(device: &Device, text: &mut TextStack) -> Self {
+        let shader = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("legend wgsl"),
+            source: ShaderSource::Wgsl(format!("{}{GRADIENT_WGSL}", super::PALETTE_WGSL).into()),
+        });
+
+        let bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("legend uniform"),
+            entries: &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::VERTEX,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Uniform,
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            }],
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("legend pipeline layout"),
+            bind_group_layouts: &[Some(&bgl)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("legend pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: PipelineCompilationOptions::default(),
+            },
+            fragment: Some(FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(ColorTargetState {
+                    format: TextureFormat::Bgra8Unorm,
+                    blend: Some(BlendState::ALPHA_BLENDING),
+                    write_mask: ColorWrites::ALL,
+                })],
+                compilation_options: PipelineCompilationOptions::default(),
+            }),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleStrip,
+                strip_index_format: None,
+                front_face: FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let uniform = device.create_buffer_init(&BufferInitDescriptor {
+            label: Some("legend uniform"),
+            contents: as_byte_slice(&[0.0f32; 8]),
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+        });
+
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("legend bind group"),
+            layout: &bgl,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: uniform.as_entire_binding(),
+            }],
+        });
+
+        let text_renderer =
+            TextRenderer::new(&mut text.atlas, device, MultisampleState::default(), None);
+
+        // Static tick labels, shaped once against the shared font system.
+        let attrs = Attrs::new().family(Family::SansSerif);
+        let labels = TICKS
+            .iter()
+            .map(|s| {
+                let mut buffer = Buffer::new(&mut text.font_system, Metrics::relative(13.0, 1.2));
+                buffer.set_text(s, &attrs, Shaping::Advanced, None);
+                buffer.shape_until_scroll(&mut text.font_system, false);
+                buffer
+            })
+            .collect();
+
+        Self {
+            pipeline,
+            bind_group,
+            uniform,
+            text_renderer,
+            labels,
+            rect: [0.0; 4],
+            visible: false,
+        }
+    }
+}
+
+impl Layer for LegendLayer {
+    fn name(&self) -> &str {
+        "legend"
+    }
+
+    fn visible(&self) -> bool {
+        self.visible
+    }
+
+    fn update(&mut self, ctx: &mut LayerCtx) {
+        self.visible = ctx.wind.visible;
+        if !self.visible {
+            return;
+        }
+
+        let (w, h) = (ctx.resolution.0 as f32, ctx.resolution.1 as f32);
+        // bottom-left corner; rect = [x, y_top, width, height] in pixels.
+        self.rect = [MARGIN_X, h - MARGIN_BOTTOM - BAR_H, BAR_W, BAR_H];
+        let u = [
+            w,
+            h,
+            self.rect[0],
+            self.rect[1],
+            self.rect[2],
+            self.rect[3],
+            0.0,
+            0.0,
+        ];
+        ctx.queue.write_buffer(&self.uniform, 0, as_byte_slice(&u));
+
+        // Labels under the bar, one per tick.
+        let top = self.rect[1] + BAR_H + 3.0;
+        let areas = self.labels.iter().enumerate().map(|(i, buffer)| {
+            let left = self.rect[0] + i as f32 / (TICKS.len() - 1) as f32 * BAR_W - 4.0;
+            TextArea {
+                buffer,
+                left,
+                top,
+                scale: 1.0,
+                bounds: TextBounds {
+                    left: left as i32,
+                    top: top as i32,
+                    right: left as i32 + 200,
+                    bottom: top as i32 + 40,
+                },
+                default_color: Color::rgb(25, 25, 25),
+                custom_glyphs: &[],
+            }
+        });
+
+        self.text_renderer
+            .prepare(
+                ctx.device,
+                ctx.queue,
+                &mut ctx.text.font_system,
+                &mut ctx.text.atlas,
+                &ctx.text.viewport,
+                areas,
+                &mut ctx.text.swash_cache,
+            )
+            .unwrap();
+    }
+
+    fn paint(&self, frame: &mut FramePass) {
+        if !self.visible {
+            return;
+        }
+
+        let mut pass = frame.encoder.begin_render_pass(&RenderPassDescriptor {
+            label: Some("legend"),
+            color_attachments: &[Some(RenderPassColorAttachment {
+                depth_slice: None,
+                view: frame.view,
+                resolve_target: None,
+                ops: Operations {
+                    load: LoadOp::Load,
+                    store: StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, &self.bind_group, &[]);
+        pass.draw(0..4, 0..1);
+        self.text_renderer
+            .render(&frame.text.atlas, &frame.text.viewport, &mut pass)
+            .unwrap();
+    }
+}

--- a/src/bin/drawing/layer/legend.rs
+++ b/src/bin/drawing/layer/legend.rs
@@ -6,11 +6,13 @@ use wgpu::*;
 use super::text::TextStack;
 use super::{FramePass, Layer, LayerCtx};
 
-/// Bar geometry in physical pixels.
-const BAR_W: f32 = 260.0;
-const BAR_H: f32 = 14.0;
-const MARGIN_X: f32 = 24.0;
-const MARGIN_BOTTOM: f32 = 40.0;
+/// Bar geometry in physical pixels (sized for hidpi/retina).
+const BAR_W: f32 = 360.0;
+const BAR_H: f32 = 28.0;
+const MARGIN_X: f32 = 40.0;
+const MARGIN_BOTTOM: f32 = 64.0;
+/// TextArea scale — matches the map's retina text handling.
+const LABEL_SCALE: f32 = 2.0;
 /// Tick labels along the bar (knots).
 const TICKS: [&str; 6] = ["0", "10", "20", "30", "40", "50 kn"];
 
@@ -193,14 +195,14 @@ impl Layer for LegendLayer {
         ctx.queue.write_buffer(&self.uniform, 0, as_byte_slice(&u));
 
         // Labels under the bar, one per tick.
-        let top = self.rect[1] + BAR_H + 3.0;
+        let top = self.rect[1] + BAR_H + 4.0;
         let areas = self.labels.iter().enumerate().map(|(i, buffer)| {
-            let left = self.rect[0] + i as f32 / (TICKS.len() - 1) as f32 * BAR_W - 4.0;
+            let left = self.rect[0] + i as f32 / (TICKS.len() - 1) as f32 * BAR_W - 6.0;
             TextArea {
                 buffer,
                 left,
                 top,
-                scale: 1.0,
+                scale: LABEL_SCALE,
                 bounds: TextBounds {
                     left: left as i32,
                     top: top as i32,

--- a/src/bin/drawing/layer/map.rs
+++ b/src/bin/drawing/layer/map.rs
@@ -10,7 +10,7 @@ use osm::drawing::as_byte_slice;
 use osm::drawing::vertex::Vertex;
 use osm::feature::collection::FeatureCollection;
 use osm::interaction::collider::{Collider, VisibleTile};
-use osm::math::{Coord, Camera, TileId, TileLocal};
+use osm::math::{Camera, Coord, TileId, TileLocal};
 use osm::object::Object;
 use osm::platform::{FileWatcher, Watcher};
 use wgpu::naga::ShaderStage;
@@ -187,7 +187,8 @@ impl MapLayer {
         let cache = Cache::new(device);
         let viewport = Viewport::new(device, &cache);
         let mut atlas = TextAtlas::new(device, queue, &cache, TextureFormat::Bgra8Unorm);
-        let text_renderer = TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
+        let text_renderer =
+            TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
 
         Self {
             blend_pipeline,
@@ -529,7 +530,9 @@ impl MapLayer {
 
         for (i, (tile_id, extent)) in visible_tiles.enumerate() {
             let matrix = camera.tile_to_screen(&tile_id);
-            data[i].transform.copy_from_slice(matrix.matrix().as_slice());
+            data[i]
+                .transform
+                .copy_from_slice(matrix.matrix().as_slice());
             data[i].extent = extent;
         }
         (
@@ -707,7 +710,9 @@ impl MapLayer {
                     // covers features without a stable id, which can't cross tiles).
                     Some(selected.feature_slot)
                 } else if selected.feature_id != 0 {
-                    self.tile_cache.get_tile(id).feature_slot(selected.feature_id)
+                    self.tile_cache
+                        .get_tile(id)
+                        .feature_slot(selected.feature_id)
                 } else {
                     None
                 };
@@ -774,38 +779,38 @@ impl Layer for MapLayer {
         });
 
         if self.labels {
-        span!(ctx.spans, "cpu.text_prep", {
-            self.viewport.update(
-                ctx.queue,
-                Resolution {
-                    width: ctx.resolution.0,
-                    height: ctx.resolution.1,
-                },
-            );
-
-            for tile_id in &self.visible_tiles {
-                let tile = self.tile_cache.get_tile_mut(tile_id);
-                tile.prepare_text(&mut self.font_system);
-            }
-            let camera = ctx.screen;
-            let tile_cache = &self.tile_cache;
-            let text_areas = self.visible_tiles.iter().flat_map(|tile_id| {
-                let tile = tile_cache.get_tile(tile_id);
-                tile.queue_text(camera)
-            });
-
-            self.text_renderer
-                .prepare(
-                    ctx.device,
+            span!(ctx.spans, "cpu.text_prep", {
+                self.viewport.update(
                     ctx.queue,
-                    &mut self.font_system,
-                    &mut self.atlas,
-                    &self.viewport,
-                    text_areas,
-                    &mut self.swash_cache,
-                )
-                .unwrap();
-        });
+                    Resolution {
+                        width: ctx.resolution.0,
+                        height: ctx.resolution.1,
+                    },
+                );
+
+                for tile_id in &self.visible_tiles {
+                    let tile = self.tile_cache.get_tile_mut(tile_id);
+                    tile.prepare_text(&mut self.font_system);
+                }
+                let camera = ctx.screen;
+                let tile_cache = &self.tile_cache;
+                let text_areas = self.visible_tiles.iter().flat_map(|tile_id| {
+                    let tile = tile_cache.get_tile(tile_id);
+                    tile.queue_text(camera)
+                });
+
+                self.text_renderer
+                    .prepare(
+                        ctx.device,
+                        ctx.queue,
+                        &mut self.font_system,
+                        &mut self.atlas,
+                        &self.viewport,
+                        text_areas,
+                        &mut self.swash_cache,
+                    )
+                    .unwrap();
+            });
         }
     }
 
@@ -893,33 +898,33 @@ impl Layer for MapLayer {
         });
 
         if self.labels {
-        span!(frame.spans, "cpu.text", {
-            let text_ts = if frame.record_gpu {
-                frame.gpu_timing.map(|g| g.writes(2, 3))
-            } else {
-                None
-            };
-            let mut pass = frame.encoder.begin_render_pass(&RenderPassDescriptor {
-                label: Some("tile text pass"),
-                color_attachments: &[Some(RenderPassColorAttachment {
-                    view: frame.view,
-                    depth_slice: None,
-                    resolve_target: None,
-                    ops: Operations {
-                        load: LoadOp::Load,
-                        store: StoreOp::Store,
-                    },
-                })],
-                depth_stencil_attachment: None,
-                timestamp_writes: text_ts,
-                occlusion_query_set: None,
-                multiview_mask: None,
-            });
+            span!(frame.spans, "cpu.text", {
+                let text_ts = if frame.record_gpu {
+                    frame.gpu_timing.map(|g| g.writes(2, 3))
+                } else {
+                    None
+                };
+                let mut pass = frame.encoder.begin_render_pass(&RenderPassDescriptor {
+                    label: Some("tile text pass"),
+                    color_attachments: &[Some(RenderPassColorAttachment {
+                        view: frame.view,
+                        depth_slice: None,
+                        resolve_target: None,
+                        ops: Operations {
+                            load: LoadOp::Load,
+                            store: StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: text_ts,
+                    occlusion_query_set: None,
+                    multiview_mask: None,
+                });
 
-            self.text_renderer
-                .render(&self.atlas, &self.viewport, &mut pass)
-                .unwrap();
-        });
+                self.text_renderer
+                    .render(&self.atlas, &self.viewport, &mut pass)
+                    .unwrap();
+            });
         }
     }
 }

--- a/src/bin/drawing/layer/map.rs
+++ b/src/bin/drawing/layer/map.rs
@@ -1,7 +1,7 @@
 use std::num::NonZeroU64;
 use std::sync::{Arc, Mutex, RwLock};
 
-use glyphon::{Cache, FontSystem, Resolution, SwashCache, TextAtlas, TextRenderer, Viewport};
+use glyphon::TextRenderer;
 use nalgebra_glm::vec2;
 use osm::cache::{CacheStats, TileCache};
 use osm::config::{MAX_FEATURES, MAX_TILES};
@@ -51,10 +51,8 @@ pub struct MapLayer {
     bind_group: BindGroup,
     shader_watcher: FileWatcher,
 
-    font_system: FontSystem,
-    swash_cache: SwashCache,
-    viewport: Viewport,
-    atlas: TextAtlas,
+    /// Own only the renderer; the font system, atlas and viewport are the shared
+    /// `TextStack` passed via the frame context.
     text_renderer: TextRenderer,
     /// Draw on-map name labels. Off by default — the hover overlay shows names
     /// instead, keeping the map uncluttered like the planetiler demo.
@@ -73,9 +71,9 @@ pub struct MapLayer {
 impl MapLayer {
     pub fn new(
         device: &Device,
-        queue: &Queue,
         camera: &Camera,
         feature_collection: Arc<RwLock<FeatureCollection>>,
+        text: &mut super::text::TextStack,
     ) -> Self {
         let shader_watcher = FileWatcher::watch(&[
             &CONFIG.renderer.vertex_shader,
@@ -167,28 +165,9 @@ impl MapLayer {
             &tile_selection_buffer,
         );
 
-        // Load the bundled Ruda font and use it for the default families. This
-        // makes text deterministic and works on the web, which has no system fonts.
-        let mut font_system = FontSystem::new_with_fonts([
-            glyphon::fontdb::Source::Binary(Arc::new(
-                include_bytes!("../../../../config/Ruda-Regular.ttf").to_vec(),
-            )),
-            glyphon::fontdb::Source::Binary(Arc::new(
-                include_bytes!("../../../../config/Ruda-Bold.ttf").to_vec(),
-            )),
-        ]);
-        {
-            let db = font_system.db_mut();
-            db.set_sans_serif_family("Ruda");
-            db.set_serif_family("Ruda");
-            db.set_monospace_family("Ruda");
-        }
-        let swash_cache = SwashCache::new();
-        let cache = Cache::new(device);
-        let viewport = Viewport::new(device, &cache);
-        let mut atlas = TextAtlas::new(device, queue, &cache, TextureFormat::Bgra8Unorm);
+        // Our own text renderer, drawing into the shared glyph atlas.
         let text_renderer =
-            TextRenderer::new(&mut atlas, device, MultisampleState::default(), None);
+            TextRenderer::new(&mut text.atlas, device, MultisampleState::default(), None);
 
         Self {
             blend_pipeline,
@@ -199,10 +178,6 @@ impl MapLayer {
             bind_group_layout,
             bind_group,
             shader_watcher,
-            font_system,
-            swash_cache,
-            viewport,
-            atlas,
             text_renderer,
             labels: false,
             tile_cache: TileCache::new(CONFIG.general.data_root.clone()),
@@ -780,17 +755,9 @@ impl Layer for MapLayer {
 
         if self.labels {
             span!(ctx.spans, "cpu.text_prep", {
-                self.viewport.update(
-                    ctx.queue,
-                    Resolution {
-                        width: ctx.resolution.0,
-                        height: ctx.resolution.1,
-                    },
-                );
-
                 for tile_id in &self.visible_tiles {
                     let tile = self.tile_cache.get_tile_mut(tile_id);
-                    tile.prepare_text(&mut self.font_system);
+                    tile.prepare_text(&mut ctx.text.font_system);
                 }
                 let camera = ctx.screen;
                 let tile_cache = &self.tile_cache;
@@ -803,11 +770,11 @@ impl Layer for MapLayer {
                     .prepare(
                         ctx.device,
                         ctx.queue,
-                        &mut self.font_system,
-                        &mut self.atlas,
-                        &self.viewport,
+                        &mut ctx.text.font_system,
+                        &mut ctx.text.atlas,
+                        &ctx.text.viewport,
                         text_areas,
-                        &mut self.swash_cache,
+                        &mut ctx.text.swash_cache,
                     )
                     .unwrap();
             });
@@ -922,7 +889,7 @@ impl Layer for MapLayer {
                 });
 
                 self.text_renderer
-                    .render(&self.atlas, &self.viewport, &mut pass)
+                    .render(&frame.text.atlas, &frame.text.viewport, &mut pass)
                     .unwrap();
             });
         }

--- a/src/bin/drawing/layer/mod.rs
+++ b/src/bin/drawing/layer/mod.rs
@@ -12,6 +12,7 @@ use osm::wind::WindModel;
 
 pub mod hover;
 pub mod map;
+pub mod particles;
 pub mod temperature;
 pub mod wind;
 

--- a/src/bin/drawing/layer/mod.rs
+++ b/src/bin/drawing/layer/mod.rs
@@ -125,6 +125,13 @@ pub trait StatSink {
 #[derive(Clone, Copy, Default)]
 pub struct ForecastTime;
 
+/// How the wind overlay draws: static arrows, or animated particle flow.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RenderMode {
+    Arrows,
+    Particles,
+}
+
 /// Wind-overlay controls the app hands the wind layer each frame (from the UI).
 /// App-agnostic value; no egui type leaks into the layer.
 #[derive(Clone, Copy)]
@@ -133,6 +140,7 @@ pub struct WindControls {
     pub model: WindModel,
     /// Target arrows across the viewport (lattice density).
     pub density: f32,
+    pub mode: RenderMode,
 }
 
 impl Default for WindControls {
@@ -141,6 +149,7 @@ impl Default for WindControls {
             visible: true,
             model: WindModel::EcmwfIfs,
             density: 10.0,
+            mode: RenderMode::Arrows,
         }
     }
 }
@@ -270,5 +279,10 @@ mod tests {
             visible: true,
         }));
         assert_eq!(stack.names_in_paint_order(), vec!["map", "temperature"]);
+    }
+
+    #[test]
+    fn wind_controls_default_mode_is_arrows() {
+        assert_eq!(WindControls::default().mode, RenderMode::Arrows);
     }
 }

--- a/src/bin/drawing/layer/mod.rs
+++ b/src/bin/drawing/layer/mod.rs
@@ -77,11 +77,9 @@ impl GpuTiming {
 
     pub fn map(&mut self) {
         let ready = self.ready.clone();
-        self.readback
-            .slice(..)
-            .map_async(MapMode::Read, move |_| {
-                ready.store(true, Ordering::Release);
-            });
+        self.readback.slice(..).map_async(MapMode::Read, move |_| {
+            ready.store(true, Ordering::Release);
+        });
         self.pending = true;
     }
 
@@ -177,6 +175,8 @@ pub struct LayerCtx<'a> {
     /// Physical render-target resolution (width, height).
     pub resolution: (u32, u32),
     pub spans: &'a mut Spans,
+    /// Present for the Layer contract; not read until forecast-time scrubbing lands.
+    #[allow(dead_code)]
     pub time: ForecastTime,
     pub wind: WindControls,
 }
@@ -197,6 +197,8 @@ pub struct FramePass<'a> {
 
 /// One composable map layer. The basemap is just one of these.
 pub trait Layer {
+    /// Used by `names_in_paint_order` (debug/tests); no live caller in the app yet.
+    #[allow(dead_code)]
     fn name(&self) -> &str;
     fn visible(&self) -> bool;
     fn update(&mut self, ctx: &mut LayerCtx);
@@ -232,6 +234,7 @@ impl LayerStack {
         }
     }
 
+    #[allow(dead_code)]
     pub fn names_in_paint_order(&self) -> Vec<&str> {
         self.layers
             .iter()

--- a/src/bin/drawing/layer/mod.rs
+++ b/src/bin/drawing/layer/mod.rs
@@ -11,10 +11,14 @@ use osm::math::{Camera, TileId};
 use osm::wind::WindModel;
 
 pub mod hover;
+pub mod legend;
 pub mod map;
 pub mod particles;
 pub mod temperature;
+pub mod text;
 pub mod wind;
+
+use text::TextStack;
 
 // Two timestamps (begin/end) for each instrumented pass: polygon, then text.
 pub const GPU_TS_COUNT: u32 = 4;
@@ -131,6 +135,27 @@ pub enum RenderMode {
     Particles,
 }
 
+/// Shared wind-speed palette. Prepend to any shader that colours by speed
+/// (arrows, particles, legend) so they all agree. Windy-style multi-hue ramp,
+/// 0..50 knots: blue -> cyan -> green -> yellow -> orange -> red/magenta.
+pub const PALETTE_WGSL: &str = r#"
+fn wind_color(kn: f32) -> vec3<f32> {
+    let t = clamp(kn / 50.0, 0.0, 1.0);
+    let c0 = vec3<f32>(0.13, 0.20, 0.55);
+    let c1 = vec3<f32>(0.13, 0.60, 0.75);
+    let c2 = vec3<f32>(0.25, 0.70, 0.30);
+    let c3 = vec3<f32>(0.85, 0.80, 0.20);
+    let c4 = vec3<f32>(0.90, 0.45, 0.15);
+    let c5 = vec3<f32>(0.75, 0.15, 0.35);
+    let s = t * 5.0;
+    if (s < 1.0) { return mix(c0, c1, s); }
+    if (s < 2.0) { return mix(c1, c2, s - 1.0); }
+    if (s < 3.0) { return mix(c2, c3, s - 2.0); }
+    if (s < 4.0) { return mix(c3, c4, s - 3.0); }
+    return mix(c4, c5, s - 4.0);
+}
+"#;
+
 /// Wind-overlay controls the app hands the wind layer each frame (from the UI).
 /// App-agnostic value; no egui type leaks into the layer.
 #[derive(Clone, Copy)]
@@ -179,6 +204,8 @@ pub struct LayerCtx<'a> {
     #[allow(dead_code)]
     pub time: ForecastTime,
     pub wind: WindControls,
+    /// Shared glyphon text resources (font + atlas) for preparing text.
+    pub text: &'a mut TextStack,
 }
 
 /// The in-flight frame a layer records draw commands into.
@@ -191,6 +218,8 @@ pub struct FramePass<'a> {
     pub depth_stencil: &'a TextureView,
     pub screen: &'a Camera,
     pub gpu_timing: Option<&'a GpuTiming>,
+    /// Shared glyphon resources (atlas + viewport) for rendering prepared text.
+    pub text: &'a TextStack,
     pub record_gpu: bool,
     pub spans: &'a mut Spans,
 }

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -66,6 +66,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     var p = parts[i];
     let uv = vec2<f32>(fract(p.pos.x), p.pos.y);
     let w = sample_wind(uv); // knots (u east, v north), bilinear
+    p.pad.x = length(w); // carry the wind speed (kn) to the draw pass for colouring
     // step in world units, scaled so on-screen speed is roughly zoom-independent.
     let step = w * u.speed / pow(2.0, u.zoom);
     p.prev = p.pos;
@@ -106,14 +107,13 @@ fn vs_main(@builtin(vertex_index) vi: u32, @builtin(instance_index) ii: u32) -> 
     let world = select(p.prev, p.pos, vi == 1u);
     var out: VsOut;
     out.pos = vec4<f32>(to_clip(world, u.center, u.scale), 0.0, 1.0);
-    out.speed = length(p.pos - p.prev);
+    out.speed = p.pad.x; // wind speed in knots, stashed by the compute pass
     return out;
 }
 
 @fragment
 fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
-    let t = clamp(in.speed * 4000.0, 0.0, 1.0);
-    return vec4<f32>(t, 0.15, 1.0 - t, 0.85);
+    return vec4<f32>(wind_color(in.speed), 0.85);
 }
 "#;
 
@@ -327,7 +327,7 @@ impl ParticleSystem {
 
         let draw_shader = device.create_shader_module(ShaderModuleDescriptor {
             label: Some("draw wgsl"),
-            source: ShaderSource::Wgsl(DRAW_WGSL.into()),
+            source: ShaderSource::Wgsl(format!("{}{DRAW_WGSL}", super::PALETTE_WGSL).into()),
         });
 
         let draw_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -197,7 +197,7 @@ impl ParticleSystem {
         let particles = device.create_buffer_init(&BufferInitDescriptor {
             label: Some("particles"),
             contents: as_byte_slice(&data),
-            usage: BufferUsages::STORAGE | BufferUsages::VERTEX | BufferUsages::COPY_DST,
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
         });
 
         // advect bind group layout: particles (rw), wind texture, sampler, uniform
@@ -607,7 +607,7 @@ impl ParticleSystem {
             }));
         }
 
-        // --- fade pass: src -> dst with REPLACE blend ---
+        // --- fade pass: src -> dst with REPLACE blend; clear dst first (fade writes every texel). ---
         {
             let fade_bg = self.fade_bgs[src].as_ref().unwrap();
             let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
@@ -616,7 +616,7 @@ impl ParticleSystem {
                     depth_slice: None,
                     view: &self.trails_views[dst],
                     resolve_target: None,
-                    ops: Operations { load: LoadOp::Load, store: StoreOp::Store },
+                    ops: Operations { load: LoadOp::Clear(Color::TRANSPARENT), store: StoreOp::Store },
                 })],
                 depth_stencil_attachment: None,
                 timestamp_writes: None,

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -93,6 +93,38 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
 }
 "#;
 
+// fullscreen triangle vertex shader shared by fade and composite passes.
+const FULLSCREEN_VS: &str = r#"
+struct VsOut { @builtin(position) pos: vec4<f32>, @location(0) uv: vec2<f32> };
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32) -> VsOut {
+    // fullscreen triangle
+    let p = array<vec2<f32>, 3>(vec2(-1.0,-1.0), vec2(3.0,-1.0), vec2(-1.0,3.0));
+    let uv = array<vec2<f32>, 3>(vec2(0.0,1.0), vec2(2.0,1.0), vec2(0.0,-1.0));
+    var o: VsOut; o.pos = vec4<f32>(p[vi], 0.0, 1.0); o.uv = uv[vi]; return o;
+}
+"#;
+
+// fade a trails texture by 0.96 each frame to create fading tails.
+const FADE_FS: &str = r#"
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+@fragment
+fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    return textureSample(t, s, uv) * 0.96;
+}
+"#;
+
+// composite the trails texture (with its alpha) over the map surface.
+const COMPOSITE_FS: &str = r#"
+@group(0) @binding(0) var t: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
+@fragment
+fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+    return textureSample(t, s, uv);
+}
+"#;
+
 /// GPU resources for the particle flow.
 pub struct ParticleSystem {
     wind_tex: Texture,
@@ -103,11 +135,28 @@ pub struct ParticleSystem {
     advect_pipeline: ComputePipeline,
     advect_bgl: BindGroupLayout,
     cu: Buffer,
+    /// segment-draw pipeline targeting Rgba8Unorm trails texture.
     draw_pipeline: RenderPipeline,
     draw_bgl: BindGroupLayout,
     du: Buffer,
     draw_bg: Option<BindGroup>,
     frame: f32,
+    /// two ping-pong Rgba8Unorm textures for accumulating fading trails.
+    trails: [Texture; 2],
+    trails_views: [TextureView; 2],
+    trails_size: (u32, u32),
+    /// which trails index is the current "src" (composite reads from it after swap).
+    src: usize,
+    /// bilinear sampler for the fullscreen fade/composite passes.
+    linear_sampler: Sampler,
+    fade_pipeline: RenderPipeline,
+    fade_bgl: BindGroupLayout,
+    composite_pipeline: RenderPipeline,
+    composite_bgl: BindGroupLayout,
+    /// pre-built fade bind groups: fade_bgs[src] samples trails[src] into trails[1-src].
+    fade_bgs: [Option<BindGroup>; 2],
+    /// pre-built composite bind group: samples trails[src] (set after swap).
+    composite_bg: Option<BindGroup>,
 }
 
 impl ParticleSystem {
@@ -259,6 +308,7 @@ impl ParticleSystem {
             immediate_size: 0,
         });
 
+        // draw pipeline targets Rgba8Unorm — it writes into the trails texture, not the surface.
         let draw_pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
             label: Some("draw particles pipeline"),
             layout: Some(&draw_layout),
@@ -272,7 +322,7 @@ impl ParticleSystem {
                 module: &draw_shader,
                 entry_point: Some("fs_main"),
                 targets: &[Some(ColorTargetState {
-                    format: TextureFormat::Bgra8Unorm,
+                    format: TextureFormat::Rgba8Unorm,
                     blend: Some(BlendState::ALPHA_BLENDING),
                     write_mask: ColorWrites::ALL,
                 })],
@@ -304,6 +354,141 @@ impl ParticleSystem {
             mapped_at_creation: false,
         });
 
+        // fullscreen texture bind group layout: texture + sampler (shared by fade and composite).
+        let tex_bgl = |device: &Device, label: &'static str| {
+            device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                label: Some(label),
+                entries: &[
+                    BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: ShaderStages::FRAGMENT,
+                        ty: BindingType::Texture {
+                            sample_type: TextureSampleType::Float { filterable: true },
+                            view_dimension: TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: ShaderStages::FRAGMENT,
+                        ty: BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+            })
+        };
+
+        let fade_bgl = tex_bgl(device, "fade bgl");
+        let composite_bgl = tex_bgl(device, "composite bgl");
+
+        let linear_sampler = device.create_sampler(&SamplerDescriptor {
+            label: Some("trails linear sampler"),
+            mag_filter: FilterMode::Linear,
+            min_filter: FilterMode::Linear,
+            ..Default::default()
+        });
+
+        let fullscreen_module = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("fullscreen vs"),
+            source: ShaderSource::Wgsl(FULLSCREEN_VS.into()),
+        });
+
+        let fade_fs_module = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("fade fs"),
+            source: ShaderSource::Wgsl(FADE_FS.into()),
+        });
+
+        let fade_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("fade pipeline layout"),
+            bind_group_layouts: &[Some(&fade_bgl)],
+            immediate_size: 0,
+        });
+
+        // fade pipeline: samples src trails, writes faded result into dst (REPLACE blend — every texel is overwritten).
+        let fade_pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("fade pipeline"),
+            layout: Some(&fade_layout),
+            vertex: VertexState {
+                module: &fullscreen_module,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: PipelineCompilationOptions::default(),
+            },
+            fragment: Some(FragmentState {
+                module: &fade_fs_module,
+                entry_point: Some("fs_main"),
+                targets: &[Some(ColorTargetState {
+                    format: TextureFormat::Rgba8Unorm,
+                    blend: Some(BlendState::REPLACE),
+                    write_mask: ColorWrites::ALL,
+                })],
+                compilation_options: PipelineCompilationOptions::default(),
+            }),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: MultisampleState { count: 1, mask: !0, alpha_to_coverage_enabled: false },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let composite_fs_module = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("composite fs"),
+            source: ShaderSource::Wgsl(COMPOSITE_FS.into()),
+        });
+
+        let composite_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("composite pipeline layout"),
+            bind_group_layouts: &[Some(&composite_bgl)],
+            immediate_size: 0,
+        });
+
+        // composite pipeline: blends the trails texture over the surface (Bgra8Unorm).
+        let composite_pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("composite pipeline"),
+            layout: Some(&composite_layout),
+            vertex: VertexState {
+                module: &fullscreen_module,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: PipelineCompilationOptions::default(),
+            },
+            fragment: Some(FragmentState {
+                module: &composite_fs_module,
+                entry_point: Some("fs_main"),
+                targets: &[Some(ColorTargetState {
+                    format: TextureFormat::Bgra8Unorm,
+                    blend: Some(BlendState::ALPHA_BLENDING),
+                    write_mask: ColorWrites::ALL,
+                })],
+                compilation_options: PipelineCompilationOptions::default(),
+            }),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::TriangleList,
+                strip_index_format: None,
+                front_face: FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: MultisampleState { count: 1, mask: !0, alpha_to_coverage_enabled: false },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        // start with a 1x1 placeholder; recreated on first render_trails call.
+        let (trails, trails_views) = make_trails(device, 1, 1);
+
         Self {
             wind_tex,
             wind_view,
@@ -318,6 +503,17 @@ impl ParticleSystem {
             du,
             draw_bg: None,
             frame: 0.0,
+            trails,
+            trails_views,
+            trails_size: (1, 1),
+            src: 0,
+            linear_sampler,
+            fade_pipeline,
+            fade_bgl,
+            composite_pipeline,
+            composite_bgl,
+            fade_bgs: [None, None],
+            composite_bg: None,
         }
     }
 
@@ -341,54 +537,112 @@ impl ParticleSystem {
         );
     }
 
-    /// Advance particles one step and rebuild the draw bind group.
-    pub fn advance(
+    /// Run compute advect + fade + segment-draw into the trails texture, then swap src/dst.
+    pub fn render_trails(
         &mut self,
         device: &Device,
         queue: &Queue,
         encoder: &mut CommandEncoder,
         camera: &Camera,
+        resolution: (u32, u32),
     ) {
         self.frame += 1.0;
-        // compute uniform: dt, speed, zoom, frame (+pad to 32 bytes)
+
+        // recreate trails textures if the resolution changed.
+        if self.trails_size != resolution {
+            let (trails, views) = make_trails(device, resolution.0, resolution.1);
+            self.trails = trails;
+            self.trails_views = views;
+            self.trails_size = resolution;
+            // invalidate cached bind groups so they're rebuilt below.
+            self.fade_bgs = [None, None];
+            self.composite_bg = None;
+        }
+
+        // --- compute advect pass ---
         let cu = [1.0f32, 0.02, camera.zoom, self.frame, 0.0, 0.0, 0.0, 0.0];
         queue.write_buffer(&self.cu, 0, as_byte_slice(&cu));
 
-        let bg = device.create_bind_group(&BindGroupDescriptor {
+        let advect_bg = device.create_bind_group(&BindGroupDescriptor {
             label: Some("advect bg"),
             layout: &self.advect_bgl,
             entries: &[
                 BindGroupEntry { binding: 0, resource: self.particles.as_entire_binding() },
-                BindGroupEntry { binding: 1, resource: BindingResource::TextureView(&self.wind_view) },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::TextureView(&self.wind_view),
+                },
                 BindGroupEntry { binding: 2, resource: BindingResource::Sampler(&self.sampler) },
                 BindGroupEntry { binding: 3, resource: self.cu.as_entire_binding() },
             ],
         });
-        let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
-            label: Some("advect"),
-            timestamp_writes: None,
-        });
-        pass.set_pipeline(&self.advect_pipeline);
-        pass.set_bind_group(0, &bg, &[]);
-        pass.dispatch_workgroups(self.count.div_ceil(64), 1, 1);
-        drop(pass);
+        {
+            let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+                label: Some("advect"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.advect_pipeline);
+            pass.set_bind_group(0, &advect_bg, &[]);
+            pass.dispatch_workgroups(self.count.div_ceil(64), 1, 1);
+        }
 
-        // draw uniform: center (f32), scale (world->clip via scale/(dim/2))
+        let src = self.src;
+        let dst = 1 - src;
+
+        // build fade bind group if missing: samples src into dst.
+        if self.fade_bgs[src].is_none() {
+            self.fade_bgs[src] = Some(device.create_bind_group(&BindGroupDescriptor {
+                label: Some("fade bg"),
+                layout: &self.fade_bgl,
+                entries: &[
+                    BindGroupEntry {
+                        binding: 0,
+                        resource: BindingResource::TextureView(&self.trails_views[src]),
+                    },
+                    BindGroupEntry {
+                        binding: 1,
+                        resource: BindingResource::Sampler(&self.linear_sampler),
+                    },
+                ],
+            }));
+        }
+
+        // --- fade pass: src -> dst with REPLACE blend ---
+        {
+            let fade_bg = self.fade_bgs[src].as_ref().unwrap();
+            let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("trails fade"),
+                color_attachments: &[Some(RenderPassColorAttachment {
+                    depth_slice: None,
+                    view: &self.trails_views[dst],
+                    resolve_target: None,
+                    ops: Operations { load: LoadOp::Load, store: StoreOp::Store },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            pass.set_pipeline(&self.fade_pipeline);
+            pass.set_bind_group(0, fade_bg, &[]);
+            pass.draw(0..3, 0..1);
+        }
+
+        // draw uniform: center (f32x2), scale (world->clip)
         let s = 2f32.powf(camera.zoom) * camera.tile_size();
         let du = [
             camera.center.x as f32,
             camera.center.y as f32,
             s / (camera.width / 2.0),
             s / (camera.height / 2.0),
-            0.0,
+            0.0f32,
             0.0,
             0.0,
             0.0,
         ];
         queue.write_buffer(&self.du, 0, as_byte_slice(&du));
 
-        // build the draw bind group here (has `device`) and store it — a bind
-        // group used in a render pass can't be created inside the pass borrow.
+        // build draw bind group (stores computed du).
         self.draw_bg = Some(device.create_bind_group(&BindGroupDescriptor {
             label: Some("draw bg"),
             layout: &self.draw_bgl,
@@ -397,15 +651,78 @@ impl ParticleSystem {
                 BindGroupEntry { binding: 1, resource: self.du.as_entire_binding() },
             ],
         }));
+
+        // --- segment pass: draw particles into dst with LoadOp::Load ---
+        {
+            let draw_bg = self.draw_bg.as_ref().unwrap();
+            let mut pass = encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("trails segments"),
+                color_attachments: &[Some(RenderPassColorAttachment {
+                    depth_slice: None,
+                    view: &self.trails_views[dst],
+                    resolve_target: None,
+                    ops: Operations { load: LoadOp::Load, store: StoreOp::Store },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            pass.set_pipeline(&self.draw_pipeline);
+            pass.set_bind_group(0, draw_bg, &[]);
+            pass.draw(0..2, 0..self.count);
+        }
+
+        // swap: dst becomes the new src for composite and the next frame.
+        self.src = dst;
+
+        // rebuild composite bind group to read from the new src.
+        self.composite_bg = Some(device.create_bind_group(&BindGroupDescriptor {
+            label: Some("composite bg"),
+            layout: &self.composite_bgl,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: BindingResource::TextureView(&self.trails_views[self.src]),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::Sampler(&self.linear_sampler),
+                },
+            ],
+        }));
+        // the fade bind group for the old dst (now src) is stale — clear it so it's rebuilt next frame.
+        self.fade_bgs[self.src] = None;
     }
 
-    /// Draw particle segments into an active render pass.
-    pub fn draw<'a>(&'a self, pass: &mut RenderPass<'a>) {
-        let Some(bg) = &self.draw_bg else { return };
-        pass.set_pipeline(&self.draw_pipeline);
+    /// Composite the trails texture over an active render pass (surface format Bgra8Unorm).
+    pub fn composite<'a>(&'a self, pass: &mut RenderPass<'a>) {
+        let Some(bg) = &self.composite_bg else { return };
+        pass.set_pipeline(&self.composite_pipeline);
         pass.set_bind_group(0, bg, &[]);
-        pass.draw(0..2, 0..self.count);
+        pass.draw(0..3, 0..1);
     }
+}
+
+/// Create two Rgba8Unorm trails textures and their views.
+fn make_trails(device: &Device, w: u32, h: u32) -> ([Texture; 2], [TextureView; 2]) {
+    let make = |label: &'static str| {
+        device.create_texture(&TextureDescriptor {
+            label: Some(label),
+            size: Extent3d { width: w, height: h, depth_or_array_layers: 1 },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: TextureFormat::Rgba8Unorm,
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        })
+    };
+    let t0 = make("trails 0");
+    let t1 = make("trails 1");
+    let v0 = t0.create_view(&TextureViewDescriptor::default());
+    let v1 = t1.create_view(&TextureViewDescriptor::default());
+    ([t0, t1], [v0, v1])
 }
 
 /// Deterministic 0..1 hash of an integer (for seeding — no rng dependency).

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -1,0 +1,107 @@
+use osm::drawing::as_byte_slice;
+use osm::wind::grid::WindGrid;
+use wgpu::util::{BufferInitDescriptor, DeviceExt};
+use wgpu::*;
+
+/// Mercator wind texture resolution (u/v per texel).
+const TEX_W: u32 = 1024;
+const TEX_H: u32 = 1024;
+
+/// Number of advected particles.
+const PARTICLES: u32 = 6000;
+
+/// One particle: current + previous world position, age, and a per-particle seed.
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+struct Particle {
+    pos: [f32; 2],
+    prev: [f32; 2],
+    age: f32,
+    seed: f32,
+    _pad: [f32; 2],
+}
+
+/// GPU resources for the particle flow. Passes are added in later tasks.
+#[allow(dead_code)]
+pub struct ParticleSystem {
+    wind_tex: Texture,
+    wind_view: TextureView,
+    sampler: Sampler,
+    particles: Buffer,
+    pub count: u32,
+}
+
+impl ParticleSystem {
+    pub fn new(device: &Device) -> Self {
+        let wind_tex = device.create_texture(&TextureDescriptor {
+            label: Some("wind uv texture"),
+            size: Extent3d { width: TEX_W, height: TEX_H, depth_or_array_layers: 1 },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: TextureFormat::Rg32Float,
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        let wind_view = wind_tex.create_view(&TextureViewDescriptor::default());
+        let sampler = device.create_sampler(&SamplerDescriptor {
+            label: Some("wind sampler"),
+            address_mode_u: AddressMode::Repeat,
+            address_mode_v: AddressMode::ClampToEdge,
+            mag_filter: FilterMode::Nearest,
+            min_filter: FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        // seed particles at hashed-random world positions so they start spread out.
+        let mut data = Vec::with_capacity(PARTICLES as usize);
+        for i in 0..PARTICLES {
+            let x = hash01(i * 2 + 1);
+            let y = hash01(i * 2 + 2);
+            data.push(Particle {
+                pos: [x, y],
+                prev: [x, y],
+                age: hash01(i * 2 + 3) * 100.0,
+                seed: i as f32,
+                _pad: [0.0, 0.0],
+            });
+        }
+        let particles = device.create_buffer_init(&BufferInitDescriptor {
+            label: Some("particles"),
+            contents: as_byte_slice(&data),
+            usage: BufferUsages::STORAGE | BufferUsages::VERTEX | BufferUsages::COPY_DST,
+        });
+
+        Self { wind_tex, wind_view, sampler, particles, count: PARTICLES }
+    }
+
+    /// Resample the grid into the mercator wind texture.
+    #[allow(dead_code)]
+    pub fn upload_wind(&self, queue: &Queue, grid: &WindGrid) {
+        let field = grid.resample_mercator(TEX_W as usize, TEX_H as usize);
+        queue.write_texture(
+            TexelCopyTextureInfo {
+                texture: &self.wind_tex,
+                mip_level: 0,
+                origin: Origin3d::ZERO,
+                aspect: TextureAspect::All,
+            },
+            as_byte_slice(&field),
+            TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(TEX_W * 8), // rg32float = 8 bytes/texel
+                rows_per_image: Some(TEX_H),
+            },
+            Extent3d { width: TEX_W, height: TEX_H, depth_or_array_layers: 1 },
+        );
+    }
+}
+
+/// Deterministic 0..1 hash of an integer (for seeding — no rng dependency).
+fn hash01(n: u32) -> f32 {
+    let mut x = n.wrapping_mul(747796405).wrapping_add(2891336453);
+    x = (x >> ((x >> 28).wrapping_add(4))) ^ x;
+    x = x.wrapping_mul(277803737);
+    x = (x >> 22) ^ x;
+    (x & 0xffffff) as f32 / 0xffffff as f32
+}

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -39,13 +39,33 @@ fn hash01(n: u32) -> f32 {
     return f32(x & 0xffffffu) / f32(0xffffffu);
 }
 
+// Manual bilinear sample of the wind texture (rg32float isn't hardware-filterable,
+// and nearest sampling gives angular, kinked flow). Longitude wraps, latitude clamps.
+fn sample_wind(uv: vec2<f32>) -> vec2<f32> {
+    let dim = vec2<f32>(textureDimensions(wind));
+    let p = uv * dim - vec2<f32>(0.5, 0.5);
+    let base = floor(p);
+    let f = p - base;
+    let w = i32(dim.x);
+    let h = i32(dim.y);
+    let x0 = ((i32(base.x) % w) + w) % w;
+    let x1 = ((i32(base.x) + 1) % w + w) % w;
+    let y0 = clamp(i32(base.y), 0, h - 1);
+    let y1 = clamp(i32(base.y) + 1, 0, h - 1);
+    let c00 = textureLoad(wind, vec2<i32>(x0, y0), 0).xy;
+    let c10 = textureLoad(wind, vec2<i32>(x1, y0), 0).xy;
+    let c01 = textureLoad(wind, vec2<i32>(x0, y1), 0).xy;
+    let c11 = textureLoad(wind, vec2<i32>(x1, y1), 0).xy;
+    return mix(mix(c00, c10, f.x), mix(c01, c11, f.x), f.y);
+}
+
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let i = gid.x;
     if (i >= arrayLength(&parts)) { return; }
     var p = parts[i];
     let uv = vec2<f32>(fract(p.pos.x), p.pos.y);
-    let w = textureSampleLevel(wind, samp, uv, 0.0).xy; // knots (u east, v north)
+    let w = sample_wind(uv); // knots (u east, v north), bilinear
     // step in world units, scaled so on-screen speed is roughly zoom-independent.
     let step = w * u.speed / pow(2.0, u.zoom);
     p.prev = p.pos;

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -1,4 +1,5 @@
 use osm::drawing::as_byte_slice;
+use osm::math::Camera;
 use osm::wind::grid::WindGrid;
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::*;
@@ -21,14 +22,92 @@ struct Particle {
     _pad: [f32; 2],
 }
 
-/// GPU resources for the particle flow. Passes are added in later tasks.
-#[allow(dead_code)]
+const ADVECT_WGSL: &str = r#"
+struct Particle { pos: vec2<f32>, prev: vec2<f32>, age: f32, seed: f32, pad: vec2<f32> };
+struct CU { dt: f32, speed: f32, zoom: f32, frame: f32, pad: vec4<f32> };
+@group(0) @binding(0) var<storage, read_write> parts: array<Particle>;
+@group(0) @binding(1) var wind: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+@group(0) @binding(3) var<uniform> u: CU;
+
+fn hash01(n: u32) -> f32 {
+    var x = n * 747796405u + 2891336453u;
+    x = ((x >> ((x >> 28u) + 4u)) ^ x) * 277803737u;
+    x = (x >> 22u) ^ x;
+    return f32(x & 0xffffffu) / f32(0xffffffu);
+}
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= arrayLength(&parts)) { return; }
+    var p = parts[i];
+    let uv = vec2<f32>(fract(p.pos.x), p.pos.y);
+    let w = textureSampleLevel(wind, samp, uv, 0.0).xy; // knots (u east, v north)
+    // step in world units, scaled so on-screen speed is roughly zoom-independent.
+    let step = w * u.speed / pow(2.0, u.zoom);
+    p.prev = p.pos;
+    // world y is +south; north wind (+v) should move the particle toward -y.
+    p.pos = vec2<f32>(p.pos.x + step.x, p.pos.y - step.y);
+    p.age = p.age + u.dt;
+    let dead = p.age > 60.0 || p.pos.y < 0.0 || p.pos.y > 1.0 || length(step) < 1e-7;
+    if (dead) {
+        let nx = hash01(i * 3u + u32(u.frame) * 2654435761u);
+        let ny = hash01(i * 5u + u32(u.frame) * 40503u + 7u);
+        p.pos = vec2<f32>(nx, ny);
+        p.prev = p.pos;
+        p.age = 0.0;
+    }
+    parts[i] = p;
+}
+"#;
+
+const DRAW_WGSL: &str = r#"
+struct Particle { pos: vec2<f32>, prev: vec2<f32>, age: f32, seed: f32, pad: vec2<f32> };
+struct DU { center: vec2<f32>, scale: vec2<f32> };
+@group(0) @binding(0) var<storage, read> parts: array<Particle>;
+@group(0) @binding(1) var<uniform> u: DU;
+
+struct VsOut { @builtin(position) pos: vec4<f32>, @location(0) speed: f32 };
+
+fn to_clip(world: vec2<f32>, center: vec2<f32>, scale: vec2<f32>) -> vec2<f32> {
+    var c = (world - center) * scale;
+    c.y = -c.y; // match the basemap y-flip
+    return c;
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vi: u32, @builtin(instance_index) ii: u32) -> VsOut {
+    let p = parts[ii];
+    let world = select(p.prev, p.pos, vi == 1u);
+    var out: VsOut;
+    out.pos = vec4<f32>(to_clip(world, u.center, u.scale), 0.0, 1.0);
+    out.speed = length(p.pos - p.prev);
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    let t = clamp(in.speed * 4000.0, 0.0, 1.0);
+    return vec4<f32>(t, 0.15, 1.0 - t, 0.85);
+}
+"#;
+
+/// GPU resources for the particle flow.
 pub struct ParticleSystem {
     wind_tex: Texture,
     wind_view: TextureView,
     sampler: Sampler,
     particles: Buffer,
     pub count: u32,
+    advect_pipeline: ComputePipeline,
+    advect_bgl: BindGroupLayout,
+    cu: Buffer,
+    draw_pipeline: RenderPipeline,
+    draw_bgl: BindGroupLayout,
+    du: Buffer,
+    draw_bg: Option<BindGroup>,
+    frame: f32,
 }
 
 impl ParticleSystem {
@@ -72,11 +151,177 @@ impl ParticleSystem {
             usage: BufferUsages::STORAGE | BufferUsages::VERTEX | BufferUsages::COPY_DST,
         });
 
-        Self { wind_tex, wind_view, sampler, particles, count: PARTICLES }
+        // advect bind group layout: particles (rw), wind texture, sampler, uniform
+        let advect_bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("advect bgl"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Texture {
+                        sample_type: TextureSampleType::Float { filterable: false },
+                        view_dimension: TextureViewDimension::D2,
+                        multisampled: false,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Sampler(SamplerBindingType::NonFiltering),
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: ShaderStages::COMPUTE,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let advect_shader = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("advect wgsl"),
+            source: ShaderSource::Wgsl(ADVECT_WGSL.into()),
+        });
+
+        let advect_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("advect pipeline layout"),
+            bind_group_layouts: &[Some(&advect_bgl)],
+            immediate_size: 0,
+        });
+
+        let advect_pipeline = device.create_compute_pipeline(&ComputePipelineDescriptor {
+            label: Some("advect pipeline"),
+            layout: Some(&advect_layout),
+            module: &advect_shader,
+            entry_point: Some("main"),
+            compilation_options: PipelineCompilationOptions::default(),
+            cache: None,
+        });
+
+        let cu = device.create_buffer(&BufferDescriptor {
+            label: Some("advect uniform"),
+            size: 32,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        // draw bind group layout: particles (readonly), uniform
+        let draw_bgl = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some("draw bgl"),
+            entries: &[
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::VERTEX,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::VERTEX,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let draw_shader = device.create_shader_module(ShaderModuleDescriptor {
+            label: Some("draw wgsl"),
+            source: ShaderSource::Wgsl(DRAW_WGSL.into()),
+        });
+
+        let draw_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            label: Some("draw pipeline layout"),
+            bind_group_layouts: &[Some(&draw_bgl)],
+            immediate_size: 0,
+        });
+
+        let draw_pipeline = device.create_render_pipeline(&RenderPipelineDescriptor {
+            label: Some("draw particles pipeline"),
+            layout: Some(&draw_layout),
+            vertex: VertexState {
+                module: &draw_shader,
+                entry_point: Some("vs_main"),
+                buffers: &[],
+                compilation_options: PipelineCompilationOptions::default(),
+            },
+            fragment: Some(FragmentState {
+                module: &draw_shader,
+                entry_point: Some("fs_main"),
+                targets: &[Some(ColorTargetState {
+                    format: TextureFormat::Bgra8Unorm,
+                    blend: Some(BlendState::ALPHA_BLENDING),
+                    write_mask: ColorWrites::ALL,
+                })],
+                compilation_options: PipelineCompilationOptions::default(),
+            }),
+            primitive: PrimitiveState {
+                topology: PrimitiveTopology::LineList,
+                strip_index_format: None,
+                front_face: FrontFace::Ccw,
+                cull_mode: None,
+                unclipped_depth: false,
+                polygon_mode: PolygonMode::Fill,
+                conservative: false,
+            },
+            depth_stencil: None,
+            multisample: MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
+            multiview_mask: None,
+            cache: None,
+        });
+
+        let du = device.create_buffer(&BufferDescriptor {
+            label: Some("draw uniform"),
+            size: 32,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self {
+            wind_tex,
+            wind_view,
+            sampler,
+            particles,
+            count: PARTICLES,
+            advect_pipeline,
+            advect_bgl,
+            cu,
+            draw_pipeline,
+            draw_bgl,
+            du,
+            draw_bg: None,
+            frame: 0.0,
+        }
     }
 
     /// Resample the grid into the mercator wind texture.
-    #[allow(dead_code)]
     pub fn upload_wind(&self, queue: &Queue, grid: &WindGrid) {
         let field = grid.resample_mercator(TEX_W as usize, TEX_H as usize);
         queue.write_texture(
@@ -94,6 +339,72 @@ impl ParticleSystem {
             },
             Extent3d { width: TEX_W, height: TEX_H, depth_or_array_layers: 1 },
         );
+    }
+
+    /// Advance particles one step and rebuild the draw bind group.
+    pub fn advance(
+        &mut self,
+        device: &Device,
+        queue: &Queue,
+        encoder: &mut CommandEncoder,
+        camera: &Camera,
+    ) {
+        self.frame += 1.0;
+        // compute uniform: dt, speed, zoom, frame (+pad to 32 bytes)
+        let cu = [1.0f32, 0.02, camera.zoom, self.frame, 0.0, 0.0, 0.0, 0.0];
+        queue.write_buffer(&self.cu, 0, as_byte_slice(&cu));
+
+        let bg = device.create_bind_group(&BindGroupDescriptor {
+            label: Some("advect bg"),
+            layout: &self.advect_bgl,
+            entries: &[
+                BindGroupEntry { binding: 0, resource: self.particles.as_entire_binding() },
+                BindGroupEntry { binding: 1, resource: BindingResource::TextureView(&self.wind_view) },
+                BindGroupEntry { binding: 2, resource: BindingResource::Sampler(&self.sampler) },
+                BindGroupEntry { binding: 3, resource: self.cu.as_entire_binding() },
+            ],
+        });
+        let mut pass = encoder.begin_compute_pass(&ComputePassDescriptor {
+            label: Some("advect"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.advect_pipeline);
+        pass.set_bind_group(0, &bg, &[]);
+        pass.dispatch_workgroups(self.count.div_ceil(64), 1, 1);
+        drop(pass);
+
+        // draw uniform: center (f32), scale (world->clip via scale/(dim/2))
+        let s = 2f32.powf(camera.zoom) * camera.tile_size();
+        let du = [
+            camera.center.x as f32,
+            camera.center.y as f32,
+            s / (camera.width / 2.0),
+            s / (camera.height / 2.0),
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ];
+        queue.write_buffer(&self.du, 0, as_byte_slice(&du));
+
+        // build the draw bind group here (has `device`) and store it — a bind
+        // group used in a render pass can't be created inside the pass borrow.
+        self.draw_bg = Some(device.create_bind_group(&BindGroupDescriptor {
+            label: Some("draw bg"),
+            layout: &self.draw_bgl,
+            entries: &[
+                BindGroupEntry { binding: 0, resource: self.particles.as_entire_binding() },
+                BindGroupEntry { binding: 1, resource: self.du.as_entire_binding() },
+            ],
+        }));
+    }
+
+    /// Draw particle segments into an active render pass.
+    pub fn draw<'a>(&'a self, pass: &mut RenderPass<'a>) {
+        let Some(bg) = &self.draw_bg else { return };
+        pass.set_pipeline(&self.draw_pipeline);
+        pass.set_bind_group(0, bg, &[]);
+        pass.draw(0..2, 0..self.count);
     }
 }
 

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -187,7 +187,11 @@ impl ParticleSystem {
     pub fn new(device: &Device) -> Self {
         let wind_tex = device.create_texture(&TextureDescriptor {
             label: Some("wind uv texture"),
-            size: Extent3d { width: TEX_W, height: TEX_H, depth_or_array_layers: 1 },
+            size: Extent3d {
+                width: TEX_W,
+                height: TEX_H,
+                depth_or_array_layers: 1,
+            },
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
@@ -459,7 +463,11 @@ impl ParticleSystem {
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: MultisampleState { count: 1, mask: !0, alpha_to_coverage_enabled: false },
+            multisample: MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
             multiview_mask: None,
             cache: None,
         });
@@ -505,7 +513,11 @@ impl ParticleSystem {
                 conservative: false,
             },
             depth_stencil: None,
-            multisample: MultisampleState { count: 1, mask: !0, alpha_to_coverage_enabled: false },
+            multisample: MultisampleState {
+                count: 1,
+                mask: !0,
+                alpha_to_coverage_enabled: false,
+            },
             multiview_mask: None,
             cache: None,
         });
@@ -557,7 +569,11 @@ impl ParticleSystem {
                 bytes_per_row: Some(TEX_W * 8), // rg32float = 8 bytes/texel
                 rows_per_image: Some(TEX_H),
             },
-            Extent3d { width: TEX_W, height: TEX_H, depth_or_array_layers: 1 },
+            Extent3d {
+                width: TEX_W,
+                height: TEX_H,
+                depth_or_array_layers: 1,
+            },
         );
     }
 
@@ -595,7 +611,7 @@ impl ParticleSystem {
         let cy = camera.center.y as f32;
         let cu = [
             1.0f32,
-            0.0015,
+            0.0004,
             camera.zoom,
             self.frame,
             cx - hx,
@@ -609,13 +625,22 @@ impl ParticleSystem {
             label: Some("advect bg"),
             layout: &self.advect_bgl,
             entries: &[
-                BindGroupEntry { binding: 0, resource: self.particles.as_entire_binding() },
+                BindGroupEntry {
+                    binding: 0,
+                    resource: self.particles.as_entire_binding(),
+                },
                 BindGroupEntry {
                     binding: 1,
                     resource: BindingResource::TextureView(&self.wind_view),
                 },
-                BindGroupEntry { binding: 2, resource: BindingResource::Sampler(&self.sampler) },
-                BindGroupEntry { binding: 3, resource: self.cu.as_entire_binding() },
+                BindGroupEntry {
+                    binding: 2,
+                    resource: BindingResource::Sampler(&self.sampler),
+                },
+                BindGroupEntry {
+                    binding: 3,
+                    resource: self.cu.as_entire_binding(),
+                },
             ],
         });
         {
@@ -658,7 +683,10 @@ impl ParticleSystem {
                     depth_slice: None,
                     view: &self.trails_views[dst],
                     resolve_target: None,
-                    ops: Operations { load: LoadOp::Clear(Color::TRANSPARENT), store: StoreOp::Store },
+                    ops: Operations {
+                        load: LoadOp::Clear(Color::TRANSPARENT),
+                        store: StoreOp::Store,
+                    },
                 })],
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
@@ -689,8 +717,14 @@ impl ParticleSystem {
             label: Some("draw bg"),
             layout: &self.draw_bgl,
             entries: &[
-                BindGroupEntry { binding: 0, resource: self.particles.as_entire_binding() },
-                BindGroupEntry { binding: 1, resource: self.du.as_entire_binding() },
+                BindGroupEntry {
+                    binding: 0,
+                    resource: self.particles.as_entire_binding(),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: self.du.as_entire_binding(),
+                },
             ],
         }));
 
@@ -703,7 +737,10 @@ impl ParticleSystem {
                     depth_slice: None,
                     view: &self.trails_views[dst],
                     resolve_target: None,
-                    ops: Operations { load: LoadOp::Load, store: StoreOp::Store },
+                    ops: Operations {
+                        load: LoadOp::Load,
+                        store: StoreOp::Store,
+                    },
                 })],
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
@@ -751,7 +788,11 @@ fn make_trails(device: &Device, w: u32, h: u32) -> ([Texture; 2], [TextureView; 
     let make = |label: &'static str| {
         device.create_texture(&TextureDescriptor {
             label: Some(label),
-            size: Extent3d { width: w, height: h, depth_or_array_layers: 1 },
+            size: Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,

--- a/src/bin/drawing/layer/particles.rs
+++ b/src/bin/drawing/layer/particles.rs
@@ -24,7 +24,9 @@ struct Particle {
 
 const ADVECT_WGSL: &str = r#"
 struct Particle { pos: vec2<f32>, prev: vec2<f32>, age: f32, seed: f32, pad: vec2<f32> };
-struct CU { dt: f32, speed: f32, zoom: f32, frame: f32, pad: vec4<f32> };
+// vmin/vmax are the viewport's world-space bounds; particles respawn inside them
+// so on-screen density holds instead of scattering across the whole globe.
+struct CU { dt: f32, speed: f32, zoom: f32, frame: f32, vmin: vec2<f32>, vmax: vec2<f32> };
 @group(0) @binding(0) var<storage, read_write> parts: array<Particle>;
 @group(0) @binding(1) var wind: texture_2d<f32>;
 @group(0) @binding(2) var samp: sampler;
@@ -50,13 +52,15 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     // world y is +south; north wind (+v) should move the particle toward -y.
     p.pos = vec2<f32>(p.pos.x + step.x, p.pos.y - step.y);
     p.age = p.age + u.dt;
-    let dead = p.age > 60.0 || p.pos.y < 0.0 || p.pos.y > 1.0 || length(step) < 1e-7;
+    let out = p.pos.x < u.vmin.x || p.pos.x > u.vmax.x || p.pos.y < u.vmin.y || p.pos.y > u.vmax.y;
+    let dead = p.age > 60.0 || out || length(step) < 1e-8;
     if (dead) {
         let nx = hash01(i * 3u + u32(u.frame) * 2654435761u);
         let ny = hash01(i * 5u + u32(u.frame) * 40503u + 7u);
-        p.pos = vec2<f32>(nx, ny);
+        // respawn inside the viewport, ages staggered so they don't all blink together.
+        p.pos = u.vmin + vec2<f32>(nx, ny) * (u.vmax - u.vmin);
         p.prev = p.pos;
-        p.age = 0.0;
+        p.age = hash01(i * 7u + u32(u.frame) + 11u) * 60.0;
     }
     parts[i] = p;
 }
@@ -560,7 +564,25 @@ impl ParticleSystem {
         }
 
         // --- compute advect pass ---
-        let cu = [1.0f32, 0.02, camera.zoom, self.frame, 0.0, 0.0, 0.0, 0.0];
+        // speed tuned so particles drift a fraction of the viewport per second,
+        // not zip across it; the /2^zoom in the shader cancels the draw scale, so
+        // on-screen speed is roughly zoom-independent. vmin/vmax are the viewport
+        // world bounds, so respawned particles stay on screen.
+        let s = 2f32.powf(camera.zoom) * camera.tile_size();
+        let hx = (camera.width / 2.0) / s;
+        let hy = (camera.height / 2.0) / s;
+        let cx = camera.center.x as f32;
+        let cy = camera.center.y as f32;
+        let cu = [
+            1.0f32,
+            0.0015,
+            camera.zoom,
+            self.frame,
+            cx - hx,
+            cy - hy,
+            cx + hx,
+            cy + hy,
+        ];
         queue.write_buffer(&self.cu, 0, as_byte_slice(&cu));
 
         let advect_bg = device.create_bind_group(&BindGroupDescriptor {

--- a/src/bin/drawing/layer/text.rs
+++ b/src/bin/drawing/layer/text.rs
@@ -1,0 +1,50 @@
+use std::sync::Arc;
+
+use glyphon::{Cache, FontSystem, Resolution, SwashCache, TextAtlas, Viewport};
+use wgpu::{Device, Queue, TextureFormat};
+
+/// Shared glyphon text resources: one font load and one glyph atlas for the
+/// whole frame. Layers keep their own cheap `TextRenderer` but prepare and
+/// render against these, so the font and atlas aren't duplicated per layer.
+pub struct TextStack {
+    pub font_system: FontSystem,
+    pub swash_cache: SwashCache,
+    pub atlas: TextAtlas,
+    pub viewport: Viewport,
+}
+
+impl TextStack {
+    pub fn new(device: &Device, queue: &Queue, format: TextureFormat) -> Self {
+        // Bundle the Ruda font so text is deterministic and works on the web,
+        // which has no system fonts.
+        let mut font_system = FontSystem::new_with_fonts([
+            glyphon::fontdb::Source::Binary(Arc::new(
+                include_bytes!("../../../../config/Ruda-Regular.ttf").to_vec(),
+            )),
+            glyphon::fontdb::Source::Binary(Arc::new(
+                include_bytes!("../../../../config/Ruda-Bold.ttf").to_vec(),
+            )),
+        ]);
+        {
+            let db = font_system.db_mut();
+            db.set_sans_serif_family("Ruda");
+            db.set_serif_family("Ruda");
+            db.set_monospace_family("Ruda");
+        }
+        let swash_cache = SwashCache::new();
+        let cache = Cache::new(device);
+        let viewport = Viewport::new(device, &cache);
+        let atlas = TextAtlas::new(device, queue, &cache, format);
+        Self {
+            font_system,
+            swash_cache,
+            atlas,
+            viewport,
+        }
+    }
+
+    /// Refresh the viewport to the current render resolution; call once per frame.
+    pub fn update_viewport(&mut self, queue: &Queue, width: u32, height: u32) {
+        self.viewport.update(queue, Resolution { width, height });
+    }
+}

--- a/src/bin/drawing/layer/wind.rs
+++ b/src/bin/drawing/layer/wind.rs
@@ -75,9 +75,8 @@ fn vs_main(in: VsIn) -> VsOut {
 
 @fragment
 fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
-    // Blue (calm) -> red (strong), saturating around 35 kn.
-    let t = clamp(in.speed / 35.0, 0.0, 1.0);
-    return vec4<f32>(t, 0.15, 1.0 - t, 0.9);
+    // in.speed is the wind magnitude in knots; colour it with the shared palette.
+    return vec4<f32>(wind_color(in.speed), 0.9);
 }
 "#;
 
@@ -117,7 +116,7 @@ impl WindLayer {
     pub fn new(device: &Device) -> Self {
         let shader = device.create_shader_module(ShaderModuleDescriptor {
             label: Some("wind wgsl"),
-            source: ShaderSource::Wgsl(WGSL.into()),
+            source: ShaderSource::Wgsl(format!("{}{WGSL}", super::PALETTE_WGSL).into()),
         });
 
         let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {

--- a/src/bin/drawing/layer/wind.rs
+++ b/src/bin/drawing/layer/wind.rs
@@ -2,12 +2,12 @@ use std::f64::consts::{FRAC_PI_4, PI};
 
 use crate::config::CONFIG;
 use osm::drawing::as_byte_slice;
-use osm::math::{num2deg, Camera, Coord, Geo, Pixel, TileCoordinate};
+use osm::math::{Camera, Coord, Geo, Pixel, TileCoordinate, num2deg};
 use osm::wind::cache::{Bbox, WindCache};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::*;
 
-use super::{particles::ParticleSystem, FramePass, Layer, LayerCtx, RenderMode};
+use super::{FramePass, Layer, LayerCtx, RenderMode, particles::ParticleSystem};
 
 /// Max arrows drawn in a frame; the lattice fetch is capped well below this.
 const MAX_INSTANCES: usize = 512;
@@ -85,10 +85,16 @@ fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
 // x runs 0..1 along the wind direction; y is the across-shaft axis.
 const ARROW: &[[f32; 2]] = &[
     // shaft quad
-    [0.0, -0.06], [0.7, -0.06], [0.7, 0.06],
-    [0.0, -0.06], [0.7, 0.06], [0.0, 0.06],
+    [0.0, -0.06],
+    [0.7, -0.06],
+    [0.7, 0.06],
+    [0.0, -0.06],
+    [0.7, 0.06],
+    [0.0, 0.06],
     // head triangle
-    [0.6, -0.18], [1.0, 0.0], [0.6, 0.18],
+    [0.6, -0.18],
+    [1.0, 0.0],
+    [0.6, 0.18],
 ];
 
 pub struct WindLayer {
@@ -332,7 +338,8 @@ impl Layer for WindLayer {
             scale: [s / (cam.width / 2.0), s / (cam.height / 2.0)],
             viewport: [cam.width, cam.height],
         };
-        ctx.queue.write_buffer(&self.uniform, 0, as_byte_slice(&[uniforms]));
+        ctx.queue
+            .write_buffer(&self.uniform, 0, as_byte_slice(&[uniforms]));
 
         // FramePass carries no device, so build the bind group here, not in paint.
         self.bind_group = Some(ctx.device.create_bind_group(&BindGroupDescriptor {
@@ -353,7 +360,10 @@ impl Layer for WindLayer {
                     depth_slice: None,
                     view: frame.view,
                     resolve_target: None,
-                    ops: Operations { load: LoadOp::Load, store: StoreOp::Store },
+                    ops: Operations {
+                        load: LoadOp::Load,
+                        store: StoreOp::Store,
+                    },
                 })],
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
@@ -364,7 +374,9 @@ impl Layer for WindLayer {
             return;
         }
 
-        let Some(bind_group) = &self.bind_group else { return };
+        let Some(bind_group) = &self.bind_group else {
+            return;
+        };
         if self.instance_count == 0 {
             return;
         }

--- a/src/bin/drawing/layer/wind.rs
+++ b/src/bin/drawing/layer/wind.rs
@@ -7,7 +7,7 @@ use osm::wind::cache::{Bbox, WindCache};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::*;
 
-use super::{particles::ParticleSystem, FramePass, Layer, LayerCtx};
+use super::{particles::ParticleSystem, FramePass, Layer, LayerCtx, RenderMode};
 
 /// Max arrows drawn in a frame; the lattice fetch is capped well below this.
 const MAX_INSTANCES: usize = 512;
@@ -91,7 +91,6 @@ const ARROW: &[[f32; 2]] = &[
     [0.6, -0.18], [1.0, 0.0], [0.6, 0.18],
 ];
 
-#[allow(dead_code)]
 pub struct WindLayer {
     pipeline: RenderPipeline,
     bind_group_layout: BindGroupLayout,
@@ -103,6 +102,9 @@ pub struct WindLayer {
     cache: WindCache,
     particles: ParticleSystem,
     visible: bool,
+    mode: RenderMode,
+    /// pointer-sized id of the loaded grid so we only re-upload on change.
+    grid_id: usize,
 }
 
 impl WindLayer {
@@ -229,6 +231,8 @@ impl WindLayer {
             cache: WindCache::new(CONFIG.general.data_root.clone()),
             particles: ParticleSystem::new(device),
             visible: true,
+            mode: RenderMode::Arrows,
+            grid_id: 0,
         }
     }
 
@@ -257,15 +261,32 @@ impl Layer for WindLayer {
     }
 
     fn visible(&self) -> bool {
-        self.visible && self.instance_count > 0
+        self.visible
+            && (self.instance_count > 0
+                || (self.mode == RenderMode::Particles && self.grid_id != 0))
     }
 
     fn update(&mut self, ctx: &mut LayerCtx) {
         let cam = ctx.screen;
         self.visible = ctx.wind.visible;
+        self.mode = ctx.wind.mode;
         self.cache
             .request(Self::viewport_bbox(cam), ctx.wind.model, ctx.wind.density);
 
+        if ctx.wind.mode == RenderMode::Particles {
+            // upload the wind grid when it first arrives or changes.
+            if let Some(grid) = self.cache.grid() {
+                let id = grid as *const _ as usize;
+                if id != self.grid_id {
+                    self.particles.upload_wind(ctx.queue, grid);
+                    self.grid_id = id;
+                }
+                self.particles.advance(ctx.device, ctx.queue, ctx.encoder, cam);
+            }
+            return;
+        }
+
+        // arrows path
         // Rebuild instances each frame: position is relative to the camera centre,
         // which moves on every pan/zoom. Subtract the centre in f64 (and project
         // lat/lon in f64) so a small offset doesn't vanish in f32 at high zoom.
@@ -319,6 +340,27 @@ impl Layer for WindLayer {
     }
 
     fn paint(&self, frame: &mut FramePass) {
+        if self.mode == RenderMode::Particles {
+            let mut pass = frame.encoder.begin_render_pass(&RenderPassDescriptor {
+                label: Some("wind particles"),
+                color_attachments: &[Some(RenderPassColorAttachment {
+                    depth_slice: None,
+                    view: frame.view,
+                    resolve_target: None,
+                    ops: Operations {
+                        load: LoadOp::Load,
+                        store: StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+                multiview_mask: None,
+            });
+            self.particles.draw(&mut pass);
+            return;
+        }
+
         let Some(bind_group) = &self.bind_group else { return };
         if self.instance_count == 0 {
             return;

--- a/src/bin/drawing/layer/wind.rs
+++ b/src/bin/drawing/layer/wind.rs
@@ -103,8 +103,8 @@ pub struct WindLayer {
     particles: ParticleSystem,
     visible: bool,
     mode: RenderMode,
-    /// pointer-sized id of the loaded grid so we only re-upload on change.
-    grid_id: usize,
+    /// generation of the last uploaded grid; 0 means none uploaded yet.
+    grid_id: u64,
 }
 
 impl WindLayer {
@@ -263,7 +263,7 @@ impl Layer for WindLayer {
     fn visible(&self) -> bool {
         self.visible
             && (self.instance_count > 0
-                || (self.mode == RenderMode::Particles && self.grid_id != 0))
+                || (self.mode == RenderMode::Particles && self.cache.grid_generation() > 0))
     }
 
     fn update(&mut self, ctx: &mut LayerCtx) {
@@ -276,10 +276,10 @@ impl Layer for WindLayer {
         if ctx.wind.mode == RenderMode::Particles {
             // upload the wind grid when it first arrives or changes.
             if let Some(grid) = self.cache.grid() {
-                let id = grid as *const _ as usize;
-                if id != self.grid_id {
+                let new_gen = self.cache.grid_generation();
+                if new_gen != self.grid_id {
                     self.particles.upload_wind(ctx.queue, grid);
-                    self.grid_id = id;
+                    self.grid_id = new_gen;
                 }
                 self.particles.render_trails(
                     ctx.device,

--- a/src/bin/drawing/layer/wind.rs
+++ b/src/bin/drawing/layer/wind.rs
@@ -7,7 +7,7 @@ use osm::wind::cache::{Bbox, WindCache};
 use wgpu::util::{BufferInitDescriptor, DeviceExt};
 use wgpu::*;
 
-use super::{FramePass, Layer, LayerCtx};
+use super::{particles::ParticleSystem, FramePass, Layer, LayerCtx};
 
 /// Max arrows drawn in a frame; the lattice fetch is capped well below this.
 const MAX_INSTANCES: usize = 512;
@@ -91,6 +91,7 @@ const ARROW: &[[f32; 2]] = &[
     [0.6, -0.18], [1.0, 0.0], [0.6, 0.18],
 ];
 
+#[allow(dead_code)]
 pub struct WindLayer {
     pipeline: RenderPipeline,
     bind_group_layout: BindGroupLayout,
@@ -100,6 +101,7 @@ pub struct WindLayer {
     instances: Buffer,
     instance_count: u32,
     cache: WindCache,
+    particles: ParticleSystem,
     visible: bool,
 }
 
@@ -225,6 +227,7 @@ impl WindLayer {
             instances,
             instance_count: 0,
             cache: WindCache::new(CONFIG.general.data_root.clone()),
+            particles: ParticleSystem::new(device),
             visible: true,
         }
     }

--- a/src/bin/drawing/layer/wind.rs
+++ b/src/bin/drawing/layer/wind.rs
@@ -281,7 +281,13 @@ impl Layer for WindLayer {
                     self.particles.upload_wind(ctx.queue, grid);
                     self.grid_id = id;
                 }
-                self.particles.advance(ctx.device, ctx.queue, ctx.encoder, cam);
+                self.particles.render_trails(
+                    ctx.device,
+                    ctx.queue,
+                    ctx.encoder,
+                    cam,
+                    ctx.resolution,
+                );
             }
             return;
         }
@@ -342,22 +348,19 @@ impl Layer for WindLayer {
     fn paint(&self, frame: &mut FramePass) {
         if self.mode == RenderMode::Particles {
             let mut pass = frame.encoder.begin_render_pass(&RenderPassDescriptor {
-                label: Some("wind particles"),
+                label: Some("wind particles composite"),
                 color_attachments: &[Some(RenderPassColorAttachment {
                     depth_slice: None,
                     view: frame.view,
                     resolve_target: None,
-                    ops: Operations {
-                        load: LoadOp::Load,
-                        store: StoreOp::Store,
-                    },
+                    ops: Operations { load: LoadOp::Load, store: StoreOp::Store },
                 })],
                 depth_stencil_attachment: None,
                 timestamp_writes: None,
                 occlusion_query_set: None,
                 multiview_mask: None,
             });
-            self.particles.draw(&mut pass);
+            self.particles.composite(&mut pass);
             return;
         }
 

--- a/src/bin/drawing/painter.rs
+++ b/src/bin/drawing/painter.rs
@@ -188,6 +188,7 @@ impl Painter {
     ///
     /// UI-agnostic: no app or map-data types here — the app owns the layers and the
     /// HUD, and passes only the camera, selection, and a stat sink.
+    #[allow(clippy::too_many_arguments)]
     pub fn paint(
         &mut self,
         map: &mut dyn Layer,
@@ -199,22 +200,21 @@ impl Painter {
         stats: &mut dyn StatSink,
     ) -> Option<Frame> {
         // Read back last frame's GPU pass timings (non-blocking) and record them.
-        if let Some(gt) = self.gpu_timing.as_mut() {
-            if let Some(raw) = gt.take(&self.device) {
-                let p = gt.period;
-                let poly = (raw[1].saturating_sub(raw[0])) as f32 * p;
-                let text = (raw[3].saturating_sub(raw[2])) as f32 * p;
-                stats.record("gpu.polygon_pass", Duration::from_nanos(poly as u64));
-                stats.record("gpu.text_pass", Duration::from_nanos(text as u64));
-            }
+        if let Some(gt) = self.gpu_timing.as_mut()
+            && let Some(raw) = gt.take(&self.device)
+        {
+            let p = gt.period;
+            let poly = (raw[1].saturating_sub(raw[0])) as f32 * p;
+            let text = (raw[3].saturating_sub(raw[2])) as f32 * p;
+            stats.record("gpu.polygon_pass", Duration::from_nanos(poly as u64));
+            stats.record("gpu.text_pass", Duration::from_nanos(text as u64));
         }
         // Only instrument the GPU this frame if last frame's readback is done,
         // so we never copy into a still-mapped buffer.
         let record_gpu = self.gpu_timing.as_ref().is_some_and(|g| !g.pending);
 
         let (wgpu::CurrentSurfaceTexture::Success(surface)
-        | wgpu::CurrentSurfaceTexture::Suboptimal(surface)) =
-            self.surface.get_current_texture()
+        | wgpu::CurrentSurfaceTexture::Suboptimal(surface)) = self.surface.get_current_texture()
         else {
             return None;
         };
@@ -274,20 +274,20 @@ impl Painter {
     /// Finishes a frame: resolves GPU timings, submits, presents, and records the
     /// remaining CPU spans. Call after the app has drawn its UI into the frame.
     pub fn present(&mut self, mut frame: Frame, stats: &mut dyn StatSink) {
-        if frame.record_gpu {
-            if let Some(gt) = self.gpu_timing.as_ref() {
-                gt.resolve(&mut frame.encoder);
-            }
+        if frame.record_gpu
+            && let Some(gt) = self.gpu_timing.as_ref()
+        {
+            gt.resolve(&mut frame.encoder);
         }
 
         let submit = web_time::Instant::now();
         self.staging_belt.finish();
         self.queue.submit([frame.encoder.finish()]);
         self.queue.present(frame.surface);
-        if frame.record_gpu {
-            if let Some(gt) = self.gpu_timing.as_mut() {
-                gt.map();
-            }
+        if frame.record_gpu
+            && let Some(gt) = self.gpu_timing.as_mut()
+        {
+            gt.map();
         }
         frame.spans.push(("cpu.submit", submit.elapsed()));
 

--- a/src/bin/drawing/painter.rs
+++ b/src/bin/drawing/painter.rs
@@ -8,6 +8,7 @@ use winit::window::Window;
 
 use osm::math::Camera;
 
+use super::layer::text::TextStack;
 use super::layer::{FramePass, GpuTiming, Layer, LayerCtx, LayerStack, Selection, Spans, StatSink};
 use crate::config::CONFIG;
 
@@ -22,6 +23,8 @@ pub struct Painter {
     multisampled_framebuffer: TextureView,
     stencil: TextureView,
     gpu_timing: Option<GpuTiming>,
+    /// Shared text resources, lent to layers each frame.
+    pub text: TextStack,
 }
 
 impl Painter {
@@ -104,6 +107,8 @@ impl Painter {
         let gpu_timing =
             timestamps_supported.then(|| GpuTiming::new(&device, queue.get_timestamp_period()));
 
+        let text = TextStack::new(&device, &queue, surface_config.format);
+
         Self {
             window,
             hidpi_factor: factor,
@@ -115,6 +120,7 @@ impl Painter {
             multisampled_framebuffer,
             stencil,
             gpu_timing,
+            text,
         }
     }
 
@@ -226,6 +232,12 @@ impl Painter {
                 label: Some("tile polygon encoder"),
             });
 
+        self.text.update_viewport(
+            &self.queue,
+            self.surface_config.width,
+            self.surface_config.height,
+        );
+
         {
             let mut ctx = LayerCtx {
                 device: &self.device,
@@ -238,6 +250,7 @@ impl Painter {
                 spans: &mut spans,
                 time: Default::default(),
                 wind,
+                text: &mut self.text,
             };
             map.update(&mut ctx);
             overlays.update_all(&mut ctx);
@@ -256,6 +269,7 @@ impl Painter {
                 depth_stencil: &self.stencil,
                 screen: camera,
                 gpu_timing: self.gpu_timing.as_ref(),
+                text: &self.text,
                 record_gpu,
                 spans: &mut spans,
             };

--- a/src/bin/drawing/ui/views/layer_toggle.rs
+++ b/src/bin/drawing/ui/views/layer_toggle.rs
@@ -16,6 +16,19 @@ pub fn view_layer_toggle(ui: &mut Ui, app_state: &mut AppState) {
                 }
             });
         ui.add(Slider::new(&mut wind.density, 4.0..=30.0).text("arrows"));
+        use crate::drawing::layer::RenderMode;
+        ui.horizontal(|ui| {
+            ui.label("Render");
+            ui.selectable_value(&mut wind.mode, RenderMode::Arrows, "arrows");
+            let grib = wind.model.uses_grib();
+            ui.add_enabled_ui(grib, |ui| {
+                ui.selectable_value(&mut wind.mode, RenderMode::Particles, "particles");
+            });
+            // fall back to arrows if the model can't do particles
+            if !grib {
+                wind.mode = RenderMode::Arrows;
+            }
+        });
     }
 
     ui.separator();

--- a/src/bin/drawing/ui/views/profiler.rs
+++ b/src/bin/drawing/ui/views/profiler.rs
@@ -12,7 +12,10 @@ pub fn view_profiler(ui: &mut Ui, app_state: &mut AppState) {
         for series in app_state.stats.series() {
             let avg = series.average().as_secs_f32() * 1000.0;
             let max = series.max().as_secs_f32() * 1000.0;
-            ui.label(format!("{}  avg {:.2}ms  max {:.2}ms", series.name, avg, max));
+            ui.label(format!(
+                "{}  avg {:.2}ms  max {:.2}ms",
+                series.name, avg, max
+            ));
 
             let (rect, _) =
                 ui.allocate_exact_size(vec2(ui.available_width(), ROW_HEIGHT), Sense::hover());
@@ -26,7 +29,10 @@ pub fn view_profiler(ui: &mut Ui, app_state: &mut AppState) {
             // Robust x-axis scale: the 98th percentile, so a rare spike doesn't
             // crush the whole distribution into the first bucket. Values above it
             // land in the last (overflow) bucket.
-            let mut ms: Vec<f32> = series.durations().map(|d| d.as_secs_f32() * 1000.0).collect();
+            let mut ms: Vec<f32> = series
+                .durations()
+                .map(|d| d.as_secs_f32() * 1000.0)
+                .collect();
             let idx = (((ms.len() as f32) * 0.98) as usize).min(ms.len() - 1);
             let scale = *ms.select_nth_unstable_by(idx, |a, b| a.total_cmp(b)).1;
             let scale = scale.max(1e-4);

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -184,14 +184,14 @@ impl Application {
             feature_collection.clone(),
         );
 
-        let painter = drawing::Painter::init(window, size).await;
+        let mut painter = drawing::Painter::init(window, size).await;
         let hud = drawing::ui::Hud::new(&painter.window, &painter.device, &painter.surface_config);
 
         let map = drawing::layer::map::MapLayer::new(
             &painter.device,
-            &painter.queue,
             &app_state.screen,
             feature_collection,
+            &mut painter.text,
         );
         let mut overlays = drawing::layer::LayerStack::new();
         overlays.push(Box::new(drawing::layer::wind::WindLayer::new(
@@ -203,6 +203,10 @@ impl Application {
         overlays.push(Box::new(drawing::layer::hover::HoverLayer::new(
             &painter.device,
             painter.surface_config.format,
+        )));
+        overlays.push(Box::new(drawing::layer::legend::LegendLayer::new(
+            &painter.device,
+            &mut painter.text,
         )));
 
         Self {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -194,8 +194,12 @@ impl Application {
             feature_collection,
         );
         let mut overlays = drawing::layer::LayerStack::new();
-        overlays.push(Box::new(drawing::layer::wind::WindLayer::new(&painter.device)));
-        overlays.push(Box::new(drawing::layer::temperature::TemperatureLayer::default()));
+        overlays.push(Box::new(drawing::layer::wind::WindLayer::new(
+            &painter.device,
+        )));
+        overlays.push(Box::new(
+            drawing::layer::temperature::TemperatureLayer::default(),
+        ));
         overlays.push(Box::new(drawing::layer::hover::HoverLayer::new(
             &painter.device,
             painter.surface_config.format,
@@ -351,13 +355,14 @@ impl Application {
 
                 self.app_state.tile_stats = self.map.tile_stats();
 
-                let selection = self.app_state.selected_object().map(|s| {
-                    drawing::layer::Selection {
-                        tile_id: s.tile_id,
-                        feature_id: s.object.feature_id,
-                        feature_slot: s.object.feature_slot,
-                    }
-                });
+                let selection =
+                    self.app_state
+                        .selected_object()
+                        .map(|s| drawing::layer::Selection {
+                            tile_id: s.tile_id,
+                            feature_id: s.object.feature_id,
+                            feature_slot: s.object.feature_slot,
+                        });
 
                 let cursor = {
                     let c = self.app_state.cursor();
@@ -374,16 +379,17 @@ impl Application {
                     cursor,
                     pixels_per_point,
                     |hover| {
-                    self.painter.paint(
-                        &mut self.map,
-                        &mut self.overlays,
-                        &self.app_state.screen,
-                        selection,
-                        hover,
-                        self.app_state.ui.wind,
-                        &mut self.app_state.stats,
-                    )
-                });
+                        self.painter.paint(
+                            &mut self.map,
+                            &mut self.overlays,
+                            &self.app_state.screen,
+                            selection,
+                            hover,
+                            self.app_state.ui.wind,
+                            &mut self.app_state.stats,
+                        )
+                    },
+                );
                 drop(hovered);
 
                 if let Some(mut frame) = painted {

--- a/src/lib/interaction/collider.rs
+++ b/src/lib/interaction/collider.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use crate::{
-    math::{Coord, Gpu, Camera, TileId},
+    math::{Camera, Coord, Gpu, TileId},
     object::Object,
 };
 

--- a/src/lib/interaction/tile_collider.rs
+++ b/src/lib/interaction/tile_collider.rs
@@ -78,9 +78,7 @@ impl TileCollider {
             let object = &self.objects[leaf as usize];
             let hit = match &object.shape {
                 Shape::Polygon(polygon) => polygon.contains(cursor),
-                Shape::Point(points) => {
-                    points.iter().any(|p| (*p - cursor).length() <= radius)
-                }
+                Shape::Point(points) => points.iter().any(|p| (*p - cursor).length() <= radius),
                 Shape::Line(points) => points
                     .windows(2)
                     .any(|w| segment_distance(cursor, w[0], w[1]) <= radius),
@@ -95,25 +93,6 @@ impl TileCollider {
 impl Default for TileCollider {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{Vec2, segment_distance};
-
-    #[test]
-    fn segment_distance_cases() {
-        let a = Vec2::new(0.0, 0.0);
-        let b = Vec2::new(10.0, 0.0);
-        // On the segment.
-        assert_eq!(segment_distance(Vec2::new(5.0, 0.0), a, b), 0.0);
-        // Perpendicular off the middle.
-        assert_eq!(segment_distance(Vec2::new(5.0, 3.0), a, b), 3.0);
-        // Past an endpoint clamps to the endpoint distance, not the infinite line.
-        assert_eq!(segment_distance(Vec2::new(-4.0, 0.0), a, b), 4.0);
-        // Degenerate segment (a == b) is the distance to the point.
-        assert_eq!(segment_distance(Vec2::new(3.0, 4.0), a, a), 5.0);
     }
 }
 
@@ -172,5 +151,24 @@ impl TileColliderLoader for Arc<RwLock<TileCollider>> {
                 }
             }
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Vec2, segment_distance};
+
+    #[test]
+    fn segment_distance_cases() {
+        let a = Vec2::new(0.0, 0.0);
+        let b = Vec2::new(10.0, 0.0);
+        // On the segment.
+        assert_eq!(segment_distance(Vec2::new(5.0, 0.0), a, b), 0.0);
+        // Perpendicular off the middle.
+        assert_eq!(segment_distance(Vec2::new(5.0, 3.0), a, b), 3.0);
+        // Past an endpoint clamps to the endpoint distance, not the infinite line.
+        assert_eq!(segment_distance(Vec2::new(-4.0, 0.0), a, b), 4.0);
+        // Degenerate segment (a == b) is the distance to the point.
+        assert_eq!(segment_distance(Vec2::new(3.0, 4.0), a, a), 5.0);
     }
 }

--- a/src/lib/vector_tile/tile.rs
+++ b/src/lib/vector_tile/tile.rs
@@ -501,10 +501,7 @@ impl Tile {
         }
     }
 
-    pub fn queue_text<'a>(
-        &'a self,
-        camera: &'a Camera,
-    ) -> impl Iterator<Item = TextArea<'a>> {
+    pub fn queue_text<'a>(&'a self, camera: &'a Camera) -> impl Iterator<Item = TextArea<'a>> {
         let matrix = camera.tile_to_screen(&self.tile_id());
         self.text
             .iter()
@@ -570,12 +567,12 @@ impl<'a> Display for Value<'a> {
             self.bool_value,
         ) {
             (Some(v), None, None, None, None, None, None) => f.write_str(v),
-            (None, Some(v), None, None, None, None, None) => f.write_fmt(format_args!("{}", &v)),
-            (None, None, Some(v), None, None, None, None) => f.write_fmt(format_args!("{}", &v)),
-            (None, None, None, Some(v), None, None, None) => f.write_fmt(format_args!("{}", &v)),
-            (None, None, None, None, Some(v), None, None) => f.write_fmt(format_args!("{}", &v)),
-            (None, None, None, None, None, Some(v), None) => f.write_fmt(format_args!("{}", &v)),
-            (None, None, None, None, None, None, Some(v)) => f.write_fmt(format_args!("{}", &v)),
+            (None, Some(v), None, None, None, None, None) => f.write_fmt(format_args!("{}", v)),
+            (None, None, Some(v), None, None, None, None) => f.write_fmt(format_args!("{}", v)),
+            (None, None, None, Some(v), None, None, None) => f.write_fmt(format_args!("{}", v)),
+            (None, None, None, None, Some(v), None, None) => f.write_fmt(format_args!("{}", v)),
+            (None, None, None, None, None, Some(v), None) => f.write_fmt(format_args!("{}", v)),
+            (None, None, None, None, None, None, Some(v)) => f.write_fmt(format_args!("{}", v)),
             _ => Ok(()),
         }
     }

--- a/src/lib/wind/cache.rs
+++ b/src/lib/wind/cache.rs
@@ -205,20 +205,20 @@ impl WindCache {
             return;
         }
 
-        if let Some((b, task)) = &mut self.loader {
-            if let Some(result) = task.try_take() {
-                let b = *b;
-                self.loader = None;
-                match result {
-                    Some(field) => {
-                        self.field = Some(field);
-                        self.loaded_bbox = Some(b);
-                        self.retry_after = None;
-                    }
-                    // Keep the last good field on screen and retry after a delay,
-                    // rather than freezing on the failed region or spamming it.
-                    None => self.retry_after = Some(now + BACKOFF),
+        if let Some((b, task)) = &mut self.loader
+            && let Some(result) = task.try_take()
+        {
+            let b = *b;
+            self.loader = None;
+            match result {
+                Some(field) => {
+                    self.field = Some(field);
+                    self.loaded_bbox = Some(b);
+                    self.retry_after = None;
                 }
+                // Keep the last good field on screen and retry after a delay,
+                // rather than freezing on the failed region or spamming it.
+                None => self.retry_after = Some(now + BACKOFF),
             }
         }
 
@@ -261,17 +261,17 @@ impl WindCache {
     fn request_grib(&mut self, bbox: Bbox, density: f32) {
         let now = Instant::now();
 
-        if let Some(task) = &mut self.grid_loader {
-            if let Some(result) = task.try_take() {
-                self.grid_loader = None;
-                match result {
-                    Some(g) => {
-                        self.grid = Some(g);
-                        self.grid_generation += 1;
-                        self.retry_after = None;
-                    }
-                    None => self.retry_after = Some(now + BACKOFF),
+        if let Some(task) = &mut self.grid_loader
+            && let Some(result) = task.try_take()
+        {
+            self.grid_loader = None;
+            match result {
+                Some(g) => {
+                    self.grid = Some(g);
+                    self.grid_generation += 1;
+                    self.retry_after = None;
                 }
+                None => self.retry_after = Some(now + BACKOFF),
             }
         }
 
@@ -330,7 +330,12 @@ mod tests {
 
     #[test]
     fn snap_expands_to_step_grid() {
-        let b = Bbox { min_lon: 8.1, min_lat: 47.2, max_lon: 8.9, max_lat: 47.7 };
+        let b = Bbox {
+            min_lon: 8.1,
+            min_lat: 47.2,
+            max_lon: 8.9,
+            max_lat: 47.7,
+        };
         let s = b.snap(0.5);
         assert!((s.min_lon - 8.0).abs() < 1e-4);
         assert!((s.min_lat - 47.0).abs() < 1e-4);
@@ -360,7 +365,12 @@ mod tests {
     // never asks for out-of-range coordinates.
     #[test]
     fn clamp_keeps_coords_valid() {
-        let b = Bbox { min_lon: -520.0, min_lat: -140.0, max_lon: 430.0, max_lat: 140.0 };
+        let b = Bbox {
+            min_lon: -520.0,
+            min_lat: -140.0,
+            max_lon: 430.0,
+            max_lat: 140.0,
+        };
         let c = b.clamp_valid();
         assert!(c.min_lon >= -180.0 && c.max_lon <= 180.0);
         assert!(c.min_lat >= -85.0 && c.max_lat <= 85.0);
@@ -369,7 +379,12 @@ mod tests {
     // Even a world-spanning viewport stays under the point cap (bounded url).
     #[test]
     fn lattice_stays_under_cap() {
-        let world = Bbox { min_lon: -180.0, min_lat: -85.0, max_lon: 180.0, max_lat: 85.0 };
+        let world = Bbox {
+            min_lon: -180.0,
+            min_lat: -85.0,
+            max_lon: 180.0,
+            max_lat: 85.0,
+        };
         let (snapped, step) = plan_lattice(world, 10.0, 0.25);
         assert!(point_count(snapped, step) <= MAX_POINTS);
     }
@@ -377,7 +392,12 @@ mod tests {
     // Same snapped bbox + step must produce a stable cache key (so disk cache hits).
     #[test]
     fn url_key_is_stable() {
-        let b = Bbox { min_lon: 8.0, min_lat: 47.0, max_lon: 9.0, max_lat: 48.0 };
+        let b = Bbox {
+            min_lon: 8.0,
+            min_lat: 47.0,
+            max_lon: 9.0,
+            max_lat: 48.0,
+        };
         let (_, k1) = open_meteo_url("ecmwf_ifs025", b, 0.5);
         let (_, k2) = open_meteo_url("ecmwf_ifs025", b, 0.5);
         assert_eq!(k1, k2);
@@ -388,7 +408,12 @@ mod tests {
     // pan: a step-1 grid over [0,2] must include the whole-degree lines.
     #[test]
     fn lattice_points_are_pinned() {
-        let b = Bbox { min_lon: 0.0, min_lat: 0.0, max_lon: 2.0, max_lat: 2.0 };
+        let b = Bbox {
+            min_lon: 0.0,
+            min_lat: 0.0,
+            max_lon: 2.0,
+            max_lat: 2.0,
+        };
         let (url, _) = open_meteo_url("ecmwf_ifs025", b, 1.0);
         assert!(url.contains("0.0000"));
         assert!(url.contains("1.0000"));
@@ -398,7 +423,12 @@ mod tests {
     // The url must request u/v-able fields in knots and the current step.
     #[test]
     fn url_requests_current_wind_in_knots() {
-        let b = Bbox { min_lon: 8.0, min_lat: 47.0, max_lon: 9.0, max_lat: 48.0 };
+        let b = Bbox {
+            min_lon: 8.0,
+            min_lat: 47.0,
+            max_lon: 9.0,
+            max_lat: 48.0,
+        };
         let (url, _) = open_meteo_url("ecmwf_ifs025", b, 0.5);
         assert!(url.contains("current=wind_speed_10m,wind_direction_10m"));
         assert!(url.contains("wind_speed_unit=kn"));

--- a/src/lib/wind/cache.rs
+++ b/src/lib/wind/cache.rs
@@ -307,6 +307,12 @@ impl WindCache {
     pub fn loaded_bbox(&self) -> Option<Bbox> {
         self.loaded_bbox
     }
+
+    /// The loaded GRIB grid, if any (None for Open-Meteo models). Lets the render
+    /// layer upload it for particle advection.
+    pub fn grid(&self) -> Option<&crate::wind::grid::WindGrid> {
+        self.grid.as_ref()
+    }
 }
 
 #[cfg(test)]

--- a/src/lib/wind/cache.rs
+++ b/src/lib/wind/cache.rs
@@ -162,6 +162,8 @@ pub struct WindCache {
     grid: Option<WindGrid>,
     /// In-flight task loading the GRIB grid.
     grid_loader: Option<Task<Option<WindGrid>>>,
+    /// incremented every time a new grid is stored; lets the render layer detect changes.
+    grid_generation: u64,
 }
 
 impl WindCache {
@@ -177,6 +179,7 @@ impl WindCache {
             density: 10.0,
             grid: None,
             grid_loader: None,
+            grid_generation: 0,
         }
     }
 
@@ -264,6 +267,7 @@ impl WindCache {
                 match result {
                     Some(g) => {
                         self.grid = Some(g);
+                        self.grid_generation += 1;
                         self.retry_after = None;
                     }
                     None => self.retry_after = Some(now + BACKOFF),
@@ -312,6 +316,11 @@ impl WindCache {
     /// layer upload it for particle advection.
     pub fn grid(&self) -> Option<&crate::wind::grid::WindGrid> {
         self.grid.as_ref()
+    }
+
+    /// Monotonically increasing counter; advances each time a new grid is stored.
+    pub fn grid_generation(&self) -> u64 {
+        self.grid_generation
     }
 }
 

--- a/src/lib/wind/ecmwf.rs
+++ b/src/lib/wind/ecmwf.rs
@@ -32,7 +32,10 @@ pub fn find_wind_ranges(index_text: &str) -> Option<(GribRange, GribRange)> {
         let Ok(e) = serde_json::from_str::<Entry>(line) else {
             continue;
         };
-        let range = GribRange { offset: e.offset, length: e.length };
+        let range = GribRange {
+            offset: e.offset,
+            length: e.length,
+        };
         match e.param.as_str() {
             "10u" => u = Some(range),
             "10v" => v = Some(range),
@@ -78,9 +81,12 @@ const ECMWF_BASE: &str = "https://data.ecmwf.int/forecasts";
 /// each message. Returns the two raw GRIB2 messages, or None if no run resolves.
 pub async fn fetch_ecmwf_wind(cache_location: &str, now_unix: i64) -> Option<(Vec<u8>, Vec<u8>)> {
     for (date, hh) in ecmwf_run_candidates(now_unix) {
-        let stem = format!("{ECMWF_BASE}/{date}/{hh:02}z/ifs/0p25/oper/{date}{hh:02}0000-0h-oper-fc");
-        let cache_u = Path::new(cache_location).join(format!("wind/ecmwf_{date}_{hh:02}_10u.grib2"));
-        let cache_v = Path::new(cache_location).join(format!("wind/ecmwf_{date}_{hh:02}_10v.grib2"));
+        let stem =
+            format!("{ECMWF_BASE}/{date}/{hh:02}z/ifs/0p25/oper/{date}{hh:02}0000-0h-oper-fc");
+        let cache_u =
+            Path::new(cache_location).join(format!("wind/ecmwf_{date}_{hh:02}_10u.grib2"));
+        let cache_v =
+            Path::new(cache_location).join(format!("wind/ecmwf_{date}_{hh:02}_10v.grib2"));
         let (cu, cv) = (cache_u.to_string_lossy(), cache_v.to_string_lossy());
 
         // serve a cached run without touching the network.
@@ -114,8 +120,20 @@ mod tests {
 {\"param\": \"10u\", \"_offset\": 20118299, \"_length\": 868687}
 {\"param\": \"10v\", \"_offset\": 24199492, \"_length\": 864428}";
         let (u, v) = find_wind_ranges(idx).unwrap();
-        assert_eq!(u, GribRange { offset: 20118299, length: 868687 });
-        assert_eq!(v, GribRange { offset: 24199492, length: 864428 });
+        assert_eq!(
+            u,
+            GribRange {
+                offset: 20118299,
+                length: 868687
+            }
+        );
+        assert_eq!(
+            v,
+            GribRange {
+                offset: 24199492,
+                length: 864428
+            }
+        );
     }
 
     #[test]

--- a/src/lib/wind/grid.rs
+++ b/src/lib/wind/grid.rs
@@ -161,7 +161,7 @@ mod tests {
         let h = 64;
         let out = g.resample_mercator(w, h);
         assert_eq!(out.len(), w * h * 2);
-        // texel row 32 (world.y = 32/64 = 0.5) is the equator -> v ~ 0.
+        // row 32 center is world_y ≈ 0.508 → lat ≈ -2.8°, so |v| < 4.
         let j = 32;
         let i = 10;
         let vv = out[(j * w + i) * 2 + 1];

--- a/src/lib/wind/grid.rs
+++ b/src/lib/wind/grid.rs
@@ -1,4 +1,5 @@
 use gribberish::message::read_messages;
+use std::f32::consts::PI;
 
 /// A decoded regular lat/lon wind field for one forecast step. Degrees for
 /// angles, knots for u/v. The lat axis descends from `lat0` by `lat_step`; the
@@ -66,6 +67,30 @@ impl WindGrid {
     }
 }
 
+impl WindGrid {
+    /// Resample into a `w`x`h` mercator-space u/v field (interleaved u,v),
+    /// row 0 = north. World y in [0,1] maps to latitude by the inverse mercator
+    /// (clamped to ±85°), longitude spans the globe. Sampling the result with
+    /// `(fract(world.x), world.y)` then needs no projection math on the gpu.
+    pub fn resample_mercator(&self, w: usize, h: usize) -> Vec<f32> {
+        let mut out = vec![0.0f32; w * h * 2];
+        for j in 0..h {
+            let world_y = (j as f32 + 0.5) / h as f32;
+            // inverse mercator: lat from normalized y (0=north, 1=south).
+            let lat_rad = 2.0 * ((PI * (1.0 - 2.0 * world_y)).exp().atan() - PI / 4.0);
+            let lat = lat_rad.to_degrees().clamp(-85.0, 85.0);
+            for i in 0..w {
+                let lon = (i as f32 + 0.5) / w as f32 * 360.0 - 180.0;
+                let (u, v) = self.sample(lon, lat);
+                let idx = (j * w + i) * 2;
+                out[idx] = u;
+                out[idx + 1] = v;
+            }
+        }
+        out
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,5 +141,30 @@ mod tests {
         // wind should be a sane magnitude in knots everywhere.
         let (u0, v0) = g.sample(8.5, 47.4); // zurich
         assert!(u0.hypot(v0) < 200.0);
+    }
+
+    #[test]
+    fn resample_matches_grid_at_texel() {
+        // small synthetic global grid: u = lon, v = lat, so we can predict samples.
+        let nlat = 181;
+        let nlon = 360;
+        let mut u = vec![0.0f32; nlat * nlon];
+        let mut v = vec![0.0f32; nlat * nlon];
+        for r in 0..nlat {
+            for c in 0..nlon {
+                u[r * nlon + c] = c as f32; // "lon index"
+                v[r * nlon + c] = 90.0 - r as f32; // latitude
+            }
+        }
+        let g = WindGrid { nlat, nlon, lat0: 90.0, lat_step: -1.0, lon0: 0.0, lon_step: 1.0, u, v };
+        let w = 64;
+        let h = 64;
+        let out = g.resample_mercator(w, h);
+        assert_eq!(out.len(), w * h * 2);
+        // texel row 32 (world.y = 32/64 = 0.5) is the equator -> v ~ 0.
+        let j = 32;
+        let i = 10;
+        let vv = out[(j * w + i) * 2 + 1];
+        assert!(vv.abs() < 4.0, "equator lat ~0, got {vv}");
     }
 }

--- a/src/lib/wind/grid.rs
+++ b/src/lib/wind/grid.rs
@@ -99,7 +99,16 @@ mod tests {
     fn grid() -> WindGrid {
         let u: Vec<f32> = (0..8).map(|i| i as f32).collect();
         let v: Vec<f32> = (0..8).map(|i| -(i as f32)).collect();
-        WindGrid { nlat: 2, nlon: 4, lat0: 90.0, lat_step: -1.0, lon0: 0.0, lon_step: 90.0, u, v }
+        WindGrid {
+            nlat: 2,
+            nlon: 4,
+            lat0: 90.0,
+            lat_step: -1.0,
+            lon0: 0.0,
+            lon_step: 90.0,
+            u,
+            v,
+        }
     }
 
     #[test]
@@ -156,7 +165,16 @@ mod tests {
                 v[r * nlon + c] = 90.0 - r as f32; // latitude
             }
         }
-        let g = WindGrid { nlat, nlon, lat0: 90.0, lat_step: -1.0, lon0: 0.0, lon_step: 1.0, u, v };
+        let g = WindGrid {
+            nlat,
+            nlon,
+            lat0: 90.0,
+            lat_step: -1.0,
+            lon0: 0.0,
+            lon_step: 1.0,
+            u,
+            v,
+        };
         let w = 64;
         let h = 64;
         let out = g.resample_mercator(w, h);

--- a/src/lib/wind/mod.rs
+++ b/src/lib/wind/mod.rs
@@ -112,8 +112,14 @@ impl WindField {
         let samples = locs
             .into_iter()
             .map(|l| {
-                let (u, v) = uv_from_speed_dir(l.current.wind_speed_10m, l.current.wind_direction_10m);
-                WindSample { lon: l.longitude, lat: l.latitude, u, v }
+                let (u, v) =
+                    uv_from_speed_dir(l.current.wind_speed_10m, l.current.wind_direction_10m);
+                WindSample {
+                    lon: l.longitude,
+                    lat: l.latitude,
+                    u,
+                    v,
+                }
             })
             .collect();
         Some(WindField { samples })


### PR DESCRIPTION
adds an animated wind particle flow as a render mode of the wind overlay, driven on the gpu by the dense ecmwf grib grid.

- render-mode toggle (arrows | particles) in the wind ui; particles only for grib-backed models
- resample the windgrid into a mercator u/v texture for the gpu
- compute shader advects ~6000 particles by bilinear-sampling the wind; ping-pong trails texture fades ~0.96/frame for the streaks; composite over the map
- particles respawn inside the viewport so on-screen density holds; speed tuned for a gentle drift; bilinear sampling for smooth curved streamlines

grib-only for now (sparse open-meteo models can't advect smoothly); compute-shader based (webgpu/native).